### PR TITLE
Move developer documentation from README to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,93 +1,140 @@
 # Contributing
 
-This document covers building from source, deploying development builds, and
-third-party credits. For end-user installation and usage, see [README.md](README.md).
+End-user install and usage: [README.md](README.md).
 
-## Getting the source
+## How the repo is organized
 
-This repo uses git submodules for native dependencies. After cloning, run:
+This project has three main pieces that must stay in sync:
+
+| Path | Role |
+|------|------|
+| `worlds/cyberpunk2077/` | Archipelago apworld — generation logic, locations, items, options |
+| `Cyberpunk2077/` | Game mod overlay copied into the Cyberpunk 2077 install (`r6/`, `bin/`, `red4ext/`) |
+| `native/` | RED4ext plugin that builds `CyberpunkAP.dll` (Archipelago connection via vendored APCpp) |
+
+At runtime the game connects **directly** to an Archipelago server — there is no separate Python client in this repo.
+
+```
+CET UI (init.lua)
+  → RedScript (TCPClient.reds, APGameSystem.reds, …)
+    → native bindings (APNativeBindings.reds)
+      → CyberpunkAP.dll (APCpp WebSocket client)
+        → Archipelago server
+```
+
+**ID sync:** `locations.py` and `items.py` are the source of truth for Archipelago IDs. The build regenerates `Cyberpunk2077/r6/scripts/.../APArchipelagoIdMappings.reds` from them and packages the matching `.apworld`. If those drift, location checks and item delivery break silently.
+
+**Native sync:** `APNativeBindings.reds` declares the C++ functions exported by `CyberpunkAP.dll`. If you change one without rebuilding/redeploying the other, RED4ext reports invalid native definitions and the game will not start.
+
+## Prerequisites
+
+- **Windows** — native plugin builds and CI both target Windows (Visual Studio + CMake).
+- **Python ~3.12** — world/apworld tooling.
+- **[Archipelago](https://github.com/ArchipelagoMW/Archipelago) source checkout** — sibling folder `../Archipelago`, or set `ARCHIPELAGO_ROOT`.
+- **Cyberpunk 2077** with the dependency mods listed in the README (RedScript, CET, Codeware, Red4Ext, RedSocket, Phone Extension).
+
+## Dev environment setup
+
+```cmd
+git clone --recurse-submodules https://github.com/247Tossing/cyberpunk_archipelago.git
+cd cyberpunk_archipelago
+```
+
+If you already cloned without submodules:
 
 ```cmd
 git submodule update --init --recursive
 ```
 
-## Native plugin (`CyberpunkAP.dll`)
-
-The RED4ext native plugin embeds the Archipelago C++ client directly into the
-game. Source lives under [`native/`](native/); see [`native/README.md`](native/README.md)
-for project layout and build details.
-
-### Build (Windows)
-
-From the `native/` folder:
+Clone Archipelago next to this repo (or anywhere — pass `--archipelago-root`):
 
 ```cmd
-cmake -S . -B build
-cmake --build build --config Release
+cd ..
+git clone https://github.com/ArchipelagoMW/Archipelago.git
 ```
 
-The output `CyberpunkAP.dll` is copied to
-`Cyberpunk2077/red4ext/plugins/CyberpunkAP/` after a successful build.
-
-### RedScript and native bindings
-
-Archipelago exposes game functions through **native** bindings declared in
-RedScript (for example `APNativeBindings.reds`). Those declarations must match
-the **`CyberpunkAP.dll`** shipped under `red4ext/plugins/CyberpunkAP/` in your
-game root.
-
-If you update **only** `r6/scripts/...` (e.g. from git) but leave an **older**
-`CyberpunkAP.dll` in place, RED4ext may report **invalid native definitions**
-and refuse to start. After any change that adds or renames natives in
-`APNativeBindings.reds`, rebuild the native plugin and copy **`CyberpunkAP.dll`**
-(and `APCpp.dll` if present next to it) from the mod's
-`Cyberpunk2077/red4ext/plugins/CyberpunkAP/` into the same path under your
-Cyberpunk 2077 install—**always deploy scripts and the RED4ext plugin together**.
-
-## Release and world build tooling
-
-Python scripts under [`tools/`](tools/) build the apworld, PopTracker pack, and
-mod zip. See [`tools/README.md`](tools/README.md) for the full pipeline,
-versioning, and CI workflow.
-
-Quick entry point for a full release build:
+The build scripts auto-link `worlds/cyberpunk2077` into the Archipelago checkout (junction on Windows, symlink elsewhere). You can also create that link manually if you prefer to work inside Archipelago directly:
 
 ```cmd
-python tools\build_release.py --archipelago-root <ARCHIPELAGO>
+mklink /J "..\Archipelago\worlds\cyberpunk2077" "%CD%\worlds\cyberpunk2077"
 ```
+
+Install Archipelago's Python deps once:
+
+```cmd
+cd ..\Archipelago
+python -m pip install -r requirements.txt
+python ModuleUpdate.py -y
+```
+
+## Building
+
+### Full release (recommended first build)
+
+Produces everything in `build/`:
+
+- `cyberpunk2077.apworld`
+- `CyberpunkArchipelagoMod_(<version>).zip`
+- `cyberpunk2077_poptracker_(<version>).zip`
+
+```cmd
+python tools\build_release.py --archipelago-root ..\Archipelago
+```
+
+This runs, in order: submodule fetch → CMake Release build of `CyberpunkAP.dll` → Archipelago world link → apworld build (including RedScript ID regeneration) → PopTracker pack → mod zip.
+
+Version comes from `world_version` in `worlds/cyberpunk2077/archipelago.json` (must be three integers, e.g. `0.6.0`). Git release tags use a matching `v` prefix (`v0.6.0`).
+
+Useful flags when iterating:
+
+| Flag | When |
+|------|------|
+| `--skip-native` | RedScript/world-only changes; DLL already built |
+| `--skip-requirements` | Archipelago deps already installed |
+| `--skip-poptracker` | Skip PopTracker pack |
+
+On Windows, release builds configure CMake with OpenSSL (`-DUSE_OPEN_SSL=ON`). CI installs OpenSSL via Chocolatey; for local native builds you need OpenSSL available to CMake or the configure step may fail.
+
+### Targeted builds
+
+| You changed | Run |
+|-------------|-----|
+| `locations.py` / `items.py` | `python tools\build_cyberpunk2077_apworld.py --archipelago-root ..\Archipelago` |
+| `native/` or `APNativeBindings.reds` | `cmake -S native -B native/build` then `cmake --build native/build --config Release` |
+| RedScript / CET Lua only | No build step — deploy overlay (below) |
+| PopTracker templates or location/item tables | `python tools\build_poptracker_pack.py --archipelago-root ..\Archipelago` |
+
+Native-only build output lands in `Cyberpunk2077/red4ext/plugins/CyberpunkAP/CyberpunkAP.dll`.
+
+More detail on individual scripts: [`tools/README.md`](tools/README.md). Native project layout: [`native/README.md`](native/README.md).
+
+## Testing in-game
+
+Copy the contents of `Cyberpunk2077/` into your Cyberpunk 2077 root (same layout as extracting the release zip: `r6/`, `bin/`, `red4ext/`).
+
+After native or RedScript binding changes, deploy **both** updated scripts and `CyberpunkAP.dll` together.
+
+Drop a freshly built `cyberpunk2077.apworld` into the Archipelago launcher (restart the launcher if it was already open). Host or join a multiworld, then in-game open the CET overlay (~), enter server IP/port/slot name, and connect.
+
+Logs: `{game dir}\bin\x64\plugins\cyber_engine_tweaks\scripting.log`
 
 ## Reporting issues
 
-Open an [Issue](https://github.com/247Tossing/cyberpunk_archipelago/issues/new/choose).
+Open an [issue](https://github.com/247Tossing/cyberpunk_archipelago/issues/new/choose) with:
 
-### What to include
+1. `spoiler.txt` from generation
+2. CET log (`scripting.log`)
+3. Archipelago server log (if local)
+4. Steps to reproduce
 
-1. Your spoiler.txt (if generated locally you can find it in `{archipelago install dir}\output\(zip used in generation)\spoiler.txt`)
-2. CET logs (you can find them in `{game dir}\bin\x64\plugins\cyber_engine_tweaks\scripting.log`)
-3. Client Logs (you can find them in `{archipelago install dir}\logs\Cyperpunk2077Client(some stuff).log`)
-4. Server Logs (if hosting locally they will be in `{archipelago install dir}\logs\Server(some stuff).log`)
-5. A good description of what exactly the issue is. I can't help if i don't know what im looking for.
+## Credits
 
-## Credits & Acknowledgements
-
-### Mod Author
-
-- **247Tossing** — Cyberpunk 2077 Archipelago Mod
-
-### Third-Party Libraries (Native Plugin)
+### Third-party libraries (native plugin)
 
 | Library | Author | Purpose |
 |---------|--------|---------|
-| [APCpp](https://github.com/N00byKing/APCpp) | N00byKing | Archipelago C++ client library (vendored + modified) |
-| [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK) | WopsS | REDengine 4 plugin SDK headers |
-| [RED4ext](https://github.com/WopsS/RED4ext) | WopsS | RED4ext loader framework (reference) |
-| [Red4Ext-template](https://github.com/ssamjoel/Red4Ext-template) | ssamjoel | Plugin project scaffold |
-| [jsoncpp](https://github.com/open-source-parsers/jsoncpp) | open-source-parsers | JSON parsing (APCpp dependency) |
-| [IXWebSocket](https://github.com/machinezone/IXWebSocket) | Machine Zone | WebSocket client (APCpp dependency) |
-| [zlib](https://github.com/madler/zlib) | Mark Adler | Compression (APCpp dependency) |
-
-### Frameworks
-
-- [Archipelago](https://archipelago.gg/) — multiworld randomizer framework
-- [RedScript](https://github.com/jac3km4/redscript) — Cyberpunk 2077 scripting framework
-- [Cyber Engine Tweaks](https://github.com/maximegmd/CyberEngineTweaks) — Cyberpunk 2077 mod engine
+| [APCpp](https://github.com/N00byKing/APCpp) | N00byKing | Archipelago C++ client (vendored + modified) |
+| [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK) | WopsS | RED4ext plugin SDK |
+| [jsoncpp](https://github.com/open-source-parsers/jsoncpp) | open-source-parsers | APCpp dependency |
+| [IXWebSocket](https://github.com/machinezone/IXWebSocket) | Machine Zone | APCpp dependency |
+| [zlib](https://github.com/madler/zlib) | Mark Adler | APCpp dependency |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+This document covers building from source, deploying development builds, and
+third-party credits. For end-user installation and usage, see [README.md](README.md).
+
+## Getting the source
+
+This repo uses git submodules for native dependencies. After cloning, run:
+
+```cmd
+git submodule update --init --recursive
+```
+
+## Native plugin (`CyberpunkAP.dll`)
+
+The RED4ext native plugin embeds the Archipelago C++ client directly into the
+game. Source lives under [`native/`](native/); see [`native/README.md`](native/README.md)
+for project layout and build details.
+
+### Build (Windows)
+
+From the `native/` folder:
+
+```cmd
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+The output `CyberpunkAP.dll` is copied to
+`Cyberpunk2077/red4ext/plugins/CyberpunkAP/` after a successful build.
+
+### RedScript and native bindings
+
+Archipelago exposes game functions through **native** bindings declared in
+RedScript (for example `APNativeBindings.reds`). Those declarations must match
+the **`CyberpunkAP.dll`** shipped under `red4ext/plugins/CyberpunkAP/` in your
+game root.
+
+If you update **only** `r6/scripts/...` (e.g. from git) but leave an **older**
+`CyberpunkAP.dll` in place, RED4ext may report **invalid native definitions**
+and refuse to start. After any change that adds or renames natives in
+`APNativeBindings.reds`, rebuild the native plugin and copy **`CyberpunkAP.dll`**
+(and `APCpp.dll` if present next to it) from the mod's
+`Cyberpunk2077/red4ext/plugins/CyberpunkAP/` into the same path under your
+Cyberpunk 2077 install—**always deploy scripts and the RED4ext plugin together**.
+
+## Release and world build tooling
+
+Python scripts under [`tools/`](tools/) build the apworld, PopTracker pack, and
+mod zip. See [`tools/README.md`](tools/README.md) for the full pipeline,
+versioning, and CI workflow.
+
+Quick entry point for a full release build:
+
+```cmd
+python tools\build_release.py --archipelago-root <ARCHIPELAGO>
+```
+
+## Reporting issues
+
+Open an [Issue](https://github.com/247Tossing/cyberpunk_archipelago/issues/new/choose).
+
+### What to include
+
+1. Your spoiler.txt (if generated locally you can find it in `{archipelago install dir}\output\(zip used in generation)\spoiler.txt`)
+2. CET logs (you can find them in `{game dir}\bin\x64\plugins\cyber_engine_tweaks\scripting.log`)
+3. Client Logs (you can find them in `{archipelago install dir}\logs\Cyperpunk2077Client(some stuff).log`)
+4. Server Logs (if hosting locally they will be in `{archipelago install dir}\logs\Server(some stuff).log`)
+5. A good description of what exactly the issue is. I can't help if i don't know what im looking for.
+
+## Credits & Acknowledgements
+
+### Mod Author
+
+- **247Tossing** — Cyberpunk 2077 Archipelago Mod
+
+### Third-Party Libraries (Native Plugin)
+
+| Library | Author | Purpose |
+|---------|--------|---------|
+| [APCpp](https://github.com/N00byKing/APCpp) | N00byKing | Archipelago C++ client library (vendored + modified) |
+| [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK) | WopsS | REDengine 4 plugin SDK headers |
+| [RED4ext](https://github.com/WopsS/RED4ext) | WopsS | RED4ext loader framework (reference) |
+| [Red4Ext-template](https://github.com/ssamjoel/Red4Ext-template) | ssamjoel | Plugin project scaffold |
+| [jsoncpp](https://github.com/open-source-parsers/jsoncpp) | open-source-parsers | JSON parsing (APCpp dependency) |
+| [IXWebSocket](https://github.com/machinezone/IXWebSocket) | Machine Zone | WebSocket client (APCpp dependency) |
+| [zlib](https://github.com/madler/zlib) | Mark Adler | Compression (APCpp dependency) |
+
+### Frameworks
+
+- [Archipelago](https://archipelago.gg/) — multiworld randomizer framework
+- [RedScript](https://github.com/jac3km4/redscript) — Cyberpunk 2077 scripting framework
+- [Cyber Engine Tweaks](https://github.com/maximegmd/CyberEngineTweaks) — Cyberpunk 2077 mod engine

--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ Download both the ```cyberpunk2077.apworld``` and ```CyberpunkArchipelagoMod.zip
 
 take the ```CyberpunkArchipelagoMod.zip``` and extract to your Cyberpunk 2077 Root folder. This should contain the ```r6``` and ```bin``` folders.
 
-### Native plugin (`CyberpunkAP.dll`) and RedScript
-
-Archipelago exposes game functions through **native** bindings declared in RedScript (for example `APNativeBindings.reds`). Those declarations must match the **`CyberpunkAP.dll`** shipped under `red4ext/plugins/CyberpunkAP/` in your game root.
-
-If you update **only** `r6/scripts/...` (e.g. from git) but leave an **older** `CyberpunkAP.dll` in place, RED4ext may report **invalid native definitions** and refuse to start. After any change that adds or renames natives in `APNativeBindings.reds`, rebuild the native plugin and copy **`CyberpunkAP.dll`** (and `APCpp.dll` if present next to it) from the mod’s `Cyberpunk2077/red4ext/plugins/CyberpunkAP/` into the same path under your Cyberpunk 2077 install—**always deploy scripts and the RED4ext plugin together**.
-
 Next, open the Archipelago Launcher and drag the ```cyberpunk2077.apworld``` file onto the launcher.
 
 You ***MUST*** restart the launcher before it will show up.
@@ -72,36 +66,14 @@ Before anything follow this guide: [Cyber Engine Tweaks Linux Instructions](http
 
 ---
 
-## Credits & Acknowledgements
+## Credits
 
-### Mod Author
 - **247Tossing** — Cyberpunk 2077 Archipelago Mod
+- Built with [Archipelago](https://archipelago.gg/), [RedScript](https://github.com/jac3km4/redscript), and [Cyber Engine Tweaks](https://github.com/maximegmd/CyberEngineTweaks)
 
-### Third-Party Libraries (Native Plugin)
-
-| Library | Author | Purpose |
-|---------|--------|---------|
-| [APCpp](https://github.com/N00byKing/APCpp) | N00byKing | Archipelago C++ client library (vendored + modified) |
-| [RED4ext.SDK](https://github.com/WopsS/RED4ext.SDK) | WopsS | REDengine 4 plugin SDK headers |
-| [RED4ext](https://github.com/WopsS/RED4ext) | WopsS | RED4ext loader framework (reference) |
-| [Red4Ext-template](https://github.com/ssamjoel/Red4Ext-template) | ssamjoel | Plugin project scaffold |
-| [jsoncpp](https://github.com/open-source-parsers/jsoncpp) | open-source-parsers | JSON parsing (APCpp dependency) |
-| [IXWebSocket](https://github.com/machinezone/IXWebSocket) | Machine Zone | WebSocket client (APCpp dependency) |
-| [zlib](https://github.com/madler/zlib) | Mark Adler | Compression (APCpp dependency) |
-
-### Frameworks
-- [Archipelago](https://archipelago.gg/) — multiworld randomizer framework
-- [RedScript](https://github.com/jac3km4/redscript) — Cyberpunk 2077 scripting framework
-- [Cyber Engine Tweaks](https://github.com/maximegmd/CyberEngineTweaks) — Cyberpunk 2077 mod engine
+Developers: see [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, issue reporting, and third-party library credits.
 
 ---
 
 ## What if something is broken?
-Open an [Issue](https://github.com/247Tossing/cyberpunk_archipelago/issues/new/choose)
-
-### What to include in your issue:
-1. Your spoiler.txt (if generated locally you can find it in ```{archipelago install dir}\output\(zip used in generation)\spoiler.txt```
-2. CET logs (you can find them in ```{game dir}\bin\x64\plugins\cyber_engine_tweaks\scripting.log```
-3. Client Logs (you can find them in ```{archipelago install dir}\logs\Cyperpunk2077Client(some stuff).log```
-4. Server Logs (if hosting locally they will be in ```{archipelago install dir}\logs\Server(some stuff).log```
-5. A good description of what exactly the issue is. I can't help if i don't know what im looking for.
+Open an [Issue](https://github.com/247Tossing/cyberpunk_archipelago/issues/new/choose). See [CONTRIBUTING.md](CONTRIBUTING.md#reporting-issues) for what to include in your report.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves developer documentation out of the main README and into `CONTRIBUTING.md`, written as a practical guide for setting up a dev environment and understanding the build pipeline.

## Changes

- **Added `CONTRIBUTING.md`** covering:
  - Repo layout (`worlds/`, `Cyberpunk2077/`, `native/`) and runtime architecture
  - ID sync (Python → RedScript mappings → apworld) and native binding sync requirements
  - Prerequisites and one-time setup (submodules, Archipelago checkout, Python deps)
  - Full and targeted build commands with a "what changed → what to run" table
  - In-game testing and log locations
  - Condensed third-party credits

- **Simplified `README.md`** for end-user install/usage with links to `CONTRIBUTING.md`

## Motivation

Release users should not wade through build-from-source instructions in the main README. Contributors need a straightforward path from clone to a working dev loop without obvious filler.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-903b4f2c-7542-4a02-9f3c-a2143df6b103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-903b4f2c-7542-4a02-9f3c-a2143df6b103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

