### PR TITLE
Add NG+ prologue bridge for v07 starts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ flowchart LR
 - **TCPClient.reds** forwards to **native** functions declared in [Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds](Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds); the implementation lives in **`CyberpunkAP.dll`** (APCpp and bridge code).
 - **APGameState** / **APGameSystem** hold and drive game-side state (items, districts, traps, phone UI, etc.).
 
+## Optional CyberpunkNewGamePlus bridge
+
+- `APNGPlusBridge.reds` provides an optional runtime integration for [CyberpunkNewGamePlus](https://github.com/alphanin9/CyberpunkNewGamePlus) (GPL-3.0). Keep this integration RedScript-only and fact-driven (`ngplus_*` quest facts) so AP remains functional when NG+ is not installed.
+- Do not vendor or bundle NG+ code/artifacts into this repository or release zips. Treat NG+ as a separate user-installed dependency.
+
 ## Hard invariant: natives and DLL stay paired
 
 Declarations in [APNativeBindings.reds](Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds) **must match** the exported API of the shipped **`CyberpunkAP.dll`**.

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APConstants.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APConstants.reds
@@ -163,6 +163,9 @@ public class APConstants {
     public static func GetQuestQ101_01_firestormDone() -> String { return "ap_q101_01_firestorm"; }
     public static func GetTarotCounterFact() -> String { return "mq033_grafitti_counter"; }
     public static func GetVPillsFact() -> String { return "q101_v_reached_pills"; }
+    public static func GetNGPlusActiveFact() -> String { return "ngplus_active"; }
+    public static func GetNGPlusQ001StartFact() -> String { return "ngplus_q001_start"; }
+    public static func GetNGPlusStandaloneQ101StartFact() -> String { return "ngplus_standalone_q101_start"; }
 
     // ===== SERVICE NAMES =====
     // CNames for retrieving services from the game engine

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -414,6 +414,7 @@ protected cb func OnMakePlayerVisibleAfterSpawn(evt: ref<EndGracePeriodAfterSpaw
         //APLogger.LogInfo( "AP Game State Defined");
         APGameState.HandlePlayerRespawn();
         APGameSystem.SyncData();
+        APNGPlusBridge.TryReleasePrologueChecksOnSpawn(GetGameInstance());
         APGameSystem.SendSyncChecks();
 
         // Register the Archipelago phone contact on every spawn

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNGPlusBridge.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNGPlusBridge.reds
@@ -1,0 +1,97 @@
+module Archipelago
+
+// Optional bridge for CyberpunkNewGamePlus integration.
+// Uses persisted quest facts so this file remains safe when NG+ is not installed.
+public class APNGPlusBridge {
+
+    // 0 = not NG+ (or unsupported start), 1 = release base prologue chain,
+    // 2 = release base prologue chain + q101_resurrection
+    private static func GetPrologueReleaseMode(questSystem: ref<QuestsSystem>) -> Int32 {
+        if !IsDefined(questSystem) {
+            return 0;
+        }
+
+        let standaloneStart: Int32 = questSystem.GetFact(StringToName(APConstants.GetNGPlusStandaloneQ101StartFact()));
+        if standaloneStart >= 1 {
+            return 2;
+        }
+
+        let ngPlusActive: Int32 = questSystem.GetFact(StringToName(APConstants.GetNGPlusActiveFact()));
+        if ngPlusActive < 1 {
+            return 0;
+        }
+
+        let q001Start: Int32 = questSystem.GetFact(StringToName(APConstants.GetNGPlusQ001StartFact()));
+        if q001Start == 0 {
+            // Q101 start skips the prologue chain checks.
+            return 2;
+        }
+
+        // Q001 start can naturally emit checks from journal progression.
+        return 0;
+    }
+
+    private static func BuildPrologueLocationIds(mode: Int32) -> array<String> {
+        let locationIds: array<String>;
+
+        if mode < 1 {
+            return locationIds;
+        }
+
+        ArrayPush(locationIds, "q000_street_kid");
+        ArrayPush(locationIds, "q001_intro");
+        ArrayPush(locationIds, "q001_01_victor");
+        ArrayPush(locationIds, "q001_02_dex");
+        ArrayPush(locationIds, "q003_maelstrom");
+        ArrayPush(locationIds, "q004_braindance");
+        ArrayPush(locationIds, "q005_heist");
+        ArrayPush(locationIds, "q101_01_firestorm");
+
+        if mode >= 2 {
+            ArrayPush(locationIds, "q101_resurrection");
+        }
+
+        return locationIds;
+    }
+
+    private static func ReleasePrologueChecks(questSystem: ref<QuestsSystem>, tcpClient: ref<TCPClient>, mode: Int32) -> Int32 {
+        let releasedCount: Int32 = 0;
+        let locationIds: array<String> = APNGPlusBridge.BuildPrologueLocationIds(mode);
+        let locationId: String;
+
+        for locationId in locationIds {
+            let factName: CName = StringToName(s"ap_\(locationId)");
+            if questSystem.GetFact(factName) < 1 {
+                APQuestLocationLookup.SendLocationCheck(questSystem, tcpClient, locationId);
+                releasedCount += 1;
+            }
+        }
+
+        return releasedCount;
+    }
+
+    public static func TryReleasePrologueChecksOnSpawn(game: GameInstance) -> Void {
+        let questSystem: ref<QuestsSystem> = GameInstance.GetQuestsSystem(game) as QuestsSystem;
+        let tcpClient: ref<TCPClient> = GameInstance.GetScriptableServiceContainer().GetService(APConstants.GetTCPClientName()) as TCPClient;
+
+        if !IsDefined(questSystem) || !IsDefined(tcpClient) {
+            return;
+        }
+
+        let mode: Int32 = APNGPlusBridge.GetPrologueReleaseMode(questSystem);
+        if mode < 1 {
+            return;
+        }
+
+        let releasedCount: Int32 = APNGPlusBridge.ReleasePrologueChecks(questSystem, tcpClient, mode);
+        if releasedCount > 0 {
+            APLogger.LogInfo(s"NG+ bridge released \(releasedCount) prologue check(s) on spawn.");
+        }
+    }
+
+    public static func IsPastPrologueForEnforcement(game: GameInstance) -> Bool {
+        let questSystem: ref<QuestsSystem> = GameInstance.GetQuestsSystem(game) as QuestsSystem;
+        let mode: Int32 = APNGPlusBridge.GetPrologueReleaseMode(questSystem);
+        return mode >= 1;
+    }
+}

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestHandler.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestHandler.reds
@@ -70,6 +70,10 @@ public class APQuestHandler extends ScriptableSystem {
 
     // Check if heist intro is complete (used for district enforcement)
     public func IsPassedPrologue() -> Bool {
+        if APNGPlusBridge.IsPastPrologueForEnforcement(this.GetGameInstance()) {
+            return true;
+        }
+
         return this.GetQuestFact(APConstants.GetQuestQ000Done()) > 0 && 
         this.GetQuestFact(APConstants.GetQuestQ001Done()) > 0 && 
         this.GetQuestFact(APConstants.GetQuestQ101_01_firestormDone()) > 0 &&

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ You will need the following mods for this to work:
 | Red4Ext | [Github Link](https://github.com/wopss/RED4ext) | [Nexus](https://www.nexusmods.com/cyberpunk2077/mods/2380)
 | Phone Extension | Unknown | [Nexus](https://www.nexusmods.com/cyberpunk2077/mods/24949)
 
+Optional companion mod (not required for normal AP runs):
+| Mod | Github Link | Nexusmods Link |
+| ----------------- | ------------------------------------------------------------------ | ------------------------------------------- |
+| CyberpunkNewGamePlus (GPL-3.0, optional) | [Github Link](https://github.com/alphanin9/CyberpunkNewGamePlus) | [Nexus](https://www.nexusmods.com/cyberpunk2077/mods/15043) |
+
 ## Mod Installation
 Download both the ```cyberpunk2077.apworld``` and ```CyberpunkArchipelagoMod.zip``` from [Releases](https://github.com/247Tossing/cyberpunk_archipelago/releases/tag/Latest)
 
@@ -45,6 +50,11 @@ If you update **only** `r6/scripts/...` (e.g. from git) but leave an **older** `
 Next, open the Archipelago Launcher and drag the ```cyberpunk2077.apworld``` file onto the launcher.
 
 You ***MUST*** restart the launcher before it will show up.
+
+### Optional NG+ bridge behavior
+
+When CyberpunkNewGamePlus is installed, this mod can auto-release skipped prologue checks for NG+ Q101/standalone starts on spawn. NG+ remains a separate install and is never bundled in the AP zip. This bridge currently targets NG+ `v1.3.1` and Cyberpunk game `2.31`.
+
 # Usage
 
 ## Using the Mod


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `APNGPlusBridge.reds` to detect NG+ save starts from persisted `ngplus_*` quest facts and release skipped prologue checks on spawn
- wire the bridge into `OnMakePlayerVisibleAfterSpawn` so release runs before `SendSyncChecks`
- treat detected NG+ Q101/standalone starts as past prologue in `APQuestHandler.IsPassedPrologue()` so district enforcement does not stay disabled
- add NG+ fact-name helpers in `APConstants.reds`
- document optional CyberpunkNewGamePlus integration in `README.md` and `AGENTS.md`

## Notes
- integration stays RedScript-only and runtime-optional; no NG+ binaries/source are bundled
- prologue release remains idempotent via `ap_<locationId>` quest facts

## Testing
- not run in cloud (requires in-game Cyberpunk 2077 + optional NG+ setup)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fce43861-3653-4462-b84c-4f99b1b0cf44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fce43861-3653-4462-b84c-4f99b1b0cf44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

