### PR TITLE
Fix late-game console errors and check release at game end

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestLocationLookup.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestLocationLookup.reds
@@ -42,6 +42,23 @@ public class APQuestLocationLookup {
             return "";
         }
 
+        // Act 3 pre-Nocturne branches — intermediate quests, not tracked separately.
+        if StrCmp(questId, "q113_rescuing_hanako") == 0
+            || StrCmp(questId, "q113_corpo") == 0 {
+            return "";
+        }
+
+        // Act 3 ending-path quests — epilogues (q201_heir aliases) cover "Ending Reached".
+        if StrCmp(questId, "q114_01_nomad_initiation") == 0
+            || StrCmp(questId, "q114_02_maglev_line_assault") == 0
+            || StrCmp(questId, "q114_03_attack_on_arasaka_tower") == 0
+            || StrCmp(questId, "q115_afterlife") == 0
+            || StrCmp(questId, "q115_rogues_last_flight") == 0
+            || StrCmp(questId, "q116_cyberspace") == 0
+            || StrCmp(questId, "09_solo") == 0 {
+            return "";
+        }
+
         return questId;
     }
 
@@ -58,5 +75,15 @@ public class APQuestLocationLookup {
 
         questSystem.SetFact(factName, 1);
         tcpService.SendCheck(locationId);
+
+        // Notify the AP server of goal completion so remaining slot checks can release.
+        if StrCmp(locationId, "q201_heir") == 0 {
+            let storyCompleteFact: CName = StringToName("ap_story_complete_sent");
+            if questSystem.GetFact(storyCompleteFact) < 1 {
+                if AP_StoryComplete() {
+                    questSystem.SetFact(storyCompleteFact, 1);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #11 by addressing the two in-scope issues reported for late-game play:

1. **Console errors for unmapped Act 3 quests** — Intermediate quests like Last Caress (`q113_rescuing_hanako`) and Totalimmortal (`q113_corpo`) were passing through `ResolveLocationId` unchanged and failing in `TCPClient.SendCheck` because they have no wire mapping. These are now suppressed (return `""`), matching the existing pattern for `q306_devils_bargain`. Same treatment for Act 3 ending-path quests (`q114_*`, `q115_*`, `q116_cyberspace`, `09_solo`).

2. **Checks not releasing at game end** — `AP_StoryComplete()` was wired in native code but never called from RedScript. When the Ending Reached check (`q201_heir`) is sent, the client now notifies the AP server with `CLIENT_GOAL` so remaining slot checks can release. Guarded by `ap_story_complete_sent` quest fact to prevent duplicate signals on respawn/sync.

## Changes

- [`APQuestLocationLookup.reds`](Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestLocationLookup.reds): quest suppressions + `AP_StoryComplete()` on ending check send

## Not in scope

- District enforcement (likely user config; deferred)
- Main quest gating feature request

## Testing

- Client-only RedScript change; no apworld rebuild required
- Verify Act 3 intermediate quests no longer log mapping errors
- Verify Ending Reached still sends check `2077001` and goal status reaches AP server once

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9f5c079-8ab0-4d9b-8e2a-a56605382229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9f5c079-8ab0-4d9b-8e2a-a56605382229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

