### PR TITLE
Fix weapon restriction config sync and pass persistence

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
@@ -15,7 +15,7 @@ public class APGameState extends ScriptableService {
     public let vendorSanityStockLine: String;
     public let vendorSanityItems: array<ref<APVendorItem>>;
 
-    // Weapon restriction settings (synced from APWorld options via SYNC_CONFIG)
+    // Weapon restriction settings (synced from APWorld options via slot_data)
     // weaponRestrictionType: 0 = none, 1 = cannotEquip (hard ban), 2 = requireMultiworldItem (pass-gated)
     public let weaponRestrictionType: Int32;
     public let weaponRestrictPistol: Bool;
@@ -25,6 +25,7 @@ public class APGameState extends ScriptableService {
     public let weaponRestrictLmg: Bool;
     public let weaponRestrictShotgun: Bool;
     public let weaponRestrictSmg: Bool;
+    public let weaponRestrictionConfigInitialized: Bool;
 
     // Item tracking
     public let items: ref<APItemList>;
@@ -97,6 +98,46 @@ public class APGameState extends ScriptableService {
         if changed {
             this.LogVendorSanitySlotDataDebug();
         }
+        return changed;
+    }
+
+    public func SetWeaponRestrictionConfig(
+        restrictionType: Int32,
+        restrictPistol: Bool,
+        restrictMelee: Bool,
+        restrictRifle: Bool,
+        restrictSniper: Bool,
+        restrictLmg: Bool,
+        restrictShotgun: Bool,
+        restrictSmg: Bool
+    ) -> Bool {
+        let changed: Bool = !this.weaponRestrictionConfigInitialized
+            || this.weaponRestrictionType < restrictionType
+            || this.weaponRestrictionType > restrictionType
+            || (this.weaponRestrictPistol && !restrictPistol)
+            || (!this.weaponRestrictPistol && restrictPistol)
+            || (this.weaponRestrictMelee && !restrictMelee)
+            || (!this.weaponRestrictMelee && restrictMelee)
+            || (this.weaponRestrictRifle && !restrictRifle)
+            || (!this.weaponRestrictRifle && restrictRifle)
+            || (this.weaponRestrictSniper && !restrictSniper)
+            || (!this.weaponRestrictSniper && restrictSniper)
+            || (this.weaponRestrictLmg && !restrictLmg)
+            || (!this.weaponRestrictLmg && restrictLmg)
+            || (this.weaponRestrictShotgun && !restrictShotgun)
+            || (!this.weaponRestrictShotgun && restrictShotgun)
+            || (this.weaponRestrictSmg && !restrictSmg)
+            || (!this.weaponRestrictSmg && restrictSmg);
+
+        this.weaponRestrictionType = restrictionType;
+        this.weaponRestrictPistol = restrictPistol;
+        this.weaponRestrictMelee = restrictMelee;
+        this.weaponRestrictRifle = restrictRifle;
+        this.weaponRestrictSniper = restrictSniper;
+        this.weaponRestrictLmg = restrictLmg;
+        this.weaponRestrictShotgun = restrictShotgun;
+        this.weaponRestrictSmg = restrictSmg;
+        this.weaponRestrictionConfigInitialized = true;
         return changed;
     }
 

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -88,6 +88,10 @@ public class APGameSystem extends ScriptableSystem {
                     // District unlock tokens (binary - just unlock)
                     this.HandleDistrictUnlock(item.itemID);
                 }
+                else if APItemParser.IsWeaponAuthorization(item.itemID) {
+                    // Weapon passes are quest-key style unlocks
+                    this.HandleWeaponUnlock(item.itemID);
+                }
                 else {
                     // Regular inventory items
                     this.inventoryHandler.GiveInventoryItem(item.itemID, difference);
@@ -311,6 +315,7 @@ public class APGameSystem extends ScriptableSystem {
         }
         else if APItemParser.IsWeaponAuthorization(item) {
             gameState.items.AddItem(item, 1);
+            this.HandleWeaponUnlock(item);
         }
         // Note: Skill points and traps not added as they're not fully implemented
     }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds
@@ -19,6 +19,14 @@ public static native func AP_GetPolledItemNotifyDisplayName() -> String
 public static native func AP_GetRestrictByMajorDistrict() -> Bool
 public static native func AP_GetRestrictBySubDistrict() -> Bool
 public static native func AP_GetDistrictTokenGatedMajorMask() -> Int32
+public static native func AP_GetWeaponRestrictionType() -> Int32
+public static native func AP_GetWeaponRestrictPistol() -> Bool
+public static native func AP_GetWeaponRestrictMelee() -> Bool
+public static native func AP_GetWeaponRestrictRifle() -> Bool
+public static native func AP_GetWeaponRestrictSniper() -> Bool
+public static native func AP_GetWeaponRestrictLmg() -> Bool
+public static native func AP_GetWeaponRestrictShotgun() -> Bool
+public static native func AP_GetWeaponRestrictSmg() -> Bool
 public static native func AP_GetVendorSanityEnabled() -> Bool
 public static native func AP_GetVendorSanityStockLine() -> String
 public static native func AP_GetDeathLinkEnabled() -> Bool

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
@@ -73,17 +73,25 @@ public class APWeaponRestrictionEnforcer extends ScriptableService {
 public final func EquipItem(itemId: ItemID, slot: Int32) -> Void {
     APLogger.LogDebug(s"Incoming Item equip attempt");
     let weaponEnforcer = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APWeaponRestrictionEnforcer") as APWeaponRestrictionEnforcer;
-    if IsDefined(weaponEnforcer) {
-        let incomingItem = itemId.GetTDBID();
-        let itemRecord: ref<Item_Record> = TweakDBInterface.GetItemRecord(incomingItem);
-        let itemType = itemRecord.ItemType().Type();
-        APLogger.LogDebug(s"Item Type is: \(itemType)");
-        if weaponEnforcer.CanEquipWeapon(itemType) {
-                APLogger.LogDebug("Weapon equip allowed");
-                wrappedMethod(itemId, slot); // Proceed with the equip action
-            } else {
-                APLogger.LogDebug("Weapon equip blocked by Archipelago restrictions");
-                return; // Block the equip action
-        }
+    if !IsDefined(weaponEnforcer) {
+        wrappedMethod(itemId, slot);
+        return;
+    }
+
+    let incomingItem = itemId.GetTDBID();
+    let itemRecord: ref<Item_Record> = TweakDBInterface.GetItemRecord(incomingItem);
+    if !IsDefined(itemRecord) {
+        wrappedMethod(itemId, slot);
+        return;
+    }
+
+    let itemType = itemRecord.ItemType().Type();
+    APLogger.LogDebug(s"Item Type is: \(itemType)");
+    if weaponEnforcer.CanEquipWeapon(itemType) {
+        APLogger.LogDebug("Weapon equip allowed");
+        wrappedMethod(itemId, slot); // Proceed with the equip action
+    } else {
+        APLogger.LogDebug("Weapon equip blocked by Archipelago restrictions");
+        return; // Block the equip action
     }
 }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -177,6 +177,22 @@ public class TCPClient extends ScriptableService {
                     }
                 }
 
+                let weaponConfigChanged: Bool = gameState.SetWeaponRestrictionConfig(
+                    AP_GetWeaponRestrictionType(),
+                    AP_GetWeaponRestrictPistol(),
+                    AP_GetWeaponRestrictMelee(),
+                    AP_GetWeaponRestrictRifle(),
+                    AP_GetWeaponRestrictSniper(),
+                    AP_GetWeaponRestrictLmg(),
+                    AP_GetWeaponRestrictShotgun(),
+                    AP_GetWeaponRestrictSmg()
+                );
+                if weaponConfigChanged {
+                    APLogger.LogInfo(
+                        s"Weapon restriction config received: type=\(gameState.weaponRestrictionType), pistol=\(gameState.weaponRestrictPistol), melee=\(gameState.weaponRestrictMelee), rifle=\(gameState.weaponRestrictRifle), sniper=\(gameState.weaponRestrictSniper), lmg=\(gameState.weaponRestrictLmg), shotgun=\(gameState.weaponRestrictShotgun), smg=\(gameState.weaponRestrictSmg)"
+                    );
+                }
+
                 let vendorChanged: Bool = gameState.SetVendorSanityData(
                     AP_GetVendorSanityEnabled(),
                     AP_GetVendorSanityStockLine()

--- a/native/cyberpunk_ap_plugin/src/APBridge.cpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.cpp
@@ -95,6 +95,14 @@ bool APBridge::Initialize(const std::string& serverAddress,
     AP_RegisterSlotDataIntCallback("restrict_by_major_district", &APBridge::OnSlotDataRestrictByMajorDistrict);
     AP_RegisterSlotDataIntCallback("restrict_by_sub_district", &APBridge::OnSlotDataRestrictBySubDistrict);
     AP_RegisterSlotDataIntCallback("district_token_gated_major_mask", &APBridge::OnSlotDataDistrictTokenGatedMajorMask);
+    AP_RegisterSlotDataIntCallback("weapon_restriction_type", &APBridge::OnSlotDataWeaponRestrictionType);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_pistol", &APBridge::OnSlotDataWeaponRestrictPistol);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_melee", &APBridge::OnSlotDataWeaponRestrictMelee);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_rifle", &APBridge::OnSlotDataWeaponRestrictRifle);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_sniper", &APBridge::OnSlotDataWeaponRestrictSniper);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_lmg", &APBridge::OnSlotDataWeaponRestrictLmg);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_shotgun", &APBridge::OnSlotDataWeaponRestrictShotgun);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_smg", &APBridge::OnSlotDataWeaponRestrictSmg);
     AP_RegisterSlotDataIntCallback("vendor_sanity", &APBridge::OnSlotDataVendorSanity);
     AP_RegisterSlotDataRawCallback("vendor_sanity_stock", &APBridge::OnSlotDataVendorSanityStock);
 
@@ -139,6 +147,14 @@ void APBridge::Shutdown()
     m_restrictByMajorDistrict = false;
     m_restrictBySubDistrict = false;
     m_districtTokenGatedMajorMask = 0;
+    m_weaponRestrictionType = 0;
+    m_weaponRestrictPistol = false;
+    m_weaponRestrictMelee = false;
+    m_weaponRestrictRifle = false;
+    m_weaponRestrictSniper = false;
+    m_weaponRestrictLmg = false;
+    m_weaponRestrictShotgun = false;
+    m_weaponRestrictSmg = false;
     m_vendorSanityEnabled = false;
     m_vendorSanityStockLine.clear();
     std::queue<ReceivedItemEntry> empty;
@@ -308,6 +324,54 @@ int32_t APBridge::GetDistrictTokenGatedMajorMask() const
     return m_districtTokenGatedMajorMask;
 }
 
+int32_t APBridge::GetWeaponRestrictionType() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictionType;
+}
+
+bool APBridge::GetWeaponRestrictPistol() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictPistol;
+}
+
+bool APBridge::GetWeaponRestrictMelee() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictMelee;
+}
+
+bool APBridge::GetWeaponRestrictRifle() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictRifle;
+}
+
+bool APBridge::GetWeaponRestrictSniper() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictSniper;
+}
+
+bool APBridge::GetWeaponRestrictLmg() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictLmg;
+}
+
+bool APBridge::GetWeaponRestrictShotgun() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictShotgun;
+}
+
+bool APBridge::GetWeaponRestrictSmg() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictSmg;
+}
+
 bool APBridge::GetVendorSanityEnabled() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -365,6 +429,46 @@ void APBridge::OnSlotDataDistrictTokenGatedMajorMask(int value)
     APBridge::Get().SetDistrictTokenGatedMajorMask(value);
 }
 
+void APBridge::OnSlotDataWeaponRestrictionType(int value)
+{
+    APBridge::Get().SetWeaponRestrictionType(value);
+}
+
+void APBridge::OnSlotDataWeaponRestrictPistol(int value)
+{
+    APBridge::Get().SetWeaponRestrictPistol(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictMelee(int value)
+{
+    APBridge::Get().SetWeaponRestrictMelee(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictRifle(int value)
+{
+    APBridge::Get().SetWeaponRestrictRifle(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictSniper(int value)
+{
+    APBridge::Get().SetWeaponRestrictSniper(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictLmg(int value)
+{
+    APBridge::Get().SetWeaponRestrictLmg(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictShotgun(int value)
+{
+    APBridge::Get().SetWeaponRestrictShotgun(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictSmg(int value)
+{
+    APBridge::Get().SetWeaponRestrictSmg(value != 0);
+}
+
 void APBridge::OnSlotDataVendorSanity(int value)
 {
     APBridge::Get().SetVendorSanityEnabled(value != 0);
@@ -409,6 +513,54 @@ void APBridge::SetDistrictTokenGatedMajorMask(int32_t value)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_districtTokenGatedMajorMask = value;
+}
+
+void APBridge::SetWeaponRestrictionType(int32_t value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictionType = value;
+}
+
+void APBridge::SetWeaponRestrictPistol(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictPistol = value;
+}
+
+void APBridge::SetWeaponRestrictMelee(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictMelee = value;
+}
+
+void APBridge::SetWeaponRestrictRifle(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictRifle = value;
+}
+
+void APBridge::SetWeaponRestrictSniper(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictSniper = value;
+}
+
+void APBridge::SetWeaponRestrictLmg(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictLmg = value;
+}
+
+void APBridge::SetWeaponRestrictShotgun(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictShotgun = value;
+}
+
+void APBridge::SetWeaponRestrictSmg(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictSmg = value;
 }
 
 void APBridge::SetVendorSanityEnabled(bool value)

--- a/native/cyberpunk_ap_plugin/src/APBridge.hpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.hpp
@@ -41,6 +41,14 @@ public:
     bool GetRestrictByMajorDistrict() const;
     bool GetRestrictBySubDistrict() const;
     int32_t GetDistrictTokenGatedMajorMask() const;
+    int32_t GetWeaponRestrictionType() const;
+    bool GetWeaponRestrictPistol() const;
+    bool GetWeaponRestrictMelee() const;
+    bool GetWeaponRestrictRifle() const;
+    bool GetWeaponRestrictSniper() const;
+    bool GetWeaponRestrictLmg() const;
+    bool GetWeaponRestrictShotgun() const;
+    bool GetWeaponRestrictSmg() const;
     bool GetVendorSanityEnabled() const;
     std::string GetVendorSanityStockLine() const;
 
@@ -57,6 +65,14 @@ private:
     static void OnSlotDataRestrictByMajorDistrict(int value);
     static void OnSlotDataRestrictBySubDistrict(int value);
     static void OnSlotDataDistrictTokenGatedMajorMask(int value);
+    static void OnSlotDataWeaponRestrictionType(int value);
+    static void OnSlotDataWeaponRestrictPistol(int value);
+    static void OnSlotDataWeaponRestrictMelee(int value);
+    static void OnSlotDataWeaponRestrictRifle(int value);
+    static void OnSlotDataWeaponRestrictSniper(int value);
+    static void OnSlotDataWeaponRestrictLmg(int value);
+    static void OnSlotDataWeaponRestrictShotgun(int value);
+    static void OnSlotDataWeaponRestrictSmg(int value);
     static void OnSlotDataVendorSanity(int value);
     static void OnSlotDataVendorSanityStock(std::string value);
 
@@ -76,6 +92,14 @@ private:
     void SetRestrictByMajorDistrict(bool value);
     void SetRestrictBySubDistrict(bool value);
     void SetDistrictTokenGatedMajorMask(int32_t value);
+    void SetWeaponRestrictionType(int32_t value);
+    void SetWeaponRestrictPistol(bool value);
+    void SetWeaponRestrictMelee(bool value);
+    void SetWeaponRestrictRifle(bool value);
+    void SetWeaponRestrictSniper(bool value);
+    void SetWeaponRestrictLmg(bool value);
+    void SetWeaponRestrictShotgun(bool value);
+    void SetWeaponRestrictSmg(bool value);
     void SetVendorSanityEnabled(bool value);
     void SetVendorSanityStockLine(const std::string& value);
 
@@ -87,6 +111,14 @@ private:
     bool m_restrictByMajorDistrict{false};
     bool m_restrictBySubDistrict{false};
     int32_t m_districtTokenGatedMajorMask{0};
+    int32_t m_weaponRestrictionType{0};
+    bool m_weaponRestrictPistol{false};
+    bool m_weaponRestrictMelee{false};
+    bool m_weaponRestrictRifle{false};
+    bool m_weaponRestrictSniper{false};
+    bool m_weaponRestrictLmg{false};
+    bool m_weaponRestrictShotgun{false};
+    bool m_weaponRestrictSmg{false};
     bool m_vendorSanityEnabled{false};
     std::string m_vendorSanityStockLine;
     std::queue<ReceivedItemEntry> m_receivedItems;

--- a/native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp
+++ b/native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp
@@ -196,6 +196,78 @@ void APGetDistrictTokenGatedMajorMask(RED4ext::IScriptable*, RED4ext::CStackFram
     }
 }
 
+void APGetWeaponRestrictionType(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictionType();
+    }
+}
+
+void APGetWeaponRestrictPistol(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictPistol();
+    }
+}
+
+void APGetWeaponRestrictMelee(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictMelee();
+    }
+}
+
+void APGetWeaponRestrictRifle(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictRifle();
+    }
+}
+
+void APGetWeaponRestrictSniper(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictSniper();
+    }
+}
+
+void APGetWeaponRestrictLmg(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictLmg();
+    }
+}
+
+void APGetWeaponRestrictShotgun(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictShotgun();
+    }
+}
+
+void APGetWeaponRestrictSmg(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictSmg();
+    }
+}
+
 void APGetVendorSanityEnabled(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
 {
     aFrame->code++;
@@ -267,6 +339,14 @@ void PostRegisterTypes()
     RegisterNative(rtti, "Archipelago.AP_GetRestrictByMajorDistrict", "AP_GetRestrictByMajorDistrict", &APGetRestrictByMajorDistrict);
     RegisterNative(rtti, "Archipelago.AP_GetRestrictBySubDistrict", "AP_GetRestrictBySubDistrict", &APGetRestrictBySubDistrict);
     RegisterNative(rtti, "Archipelago.AP_GetDistrictTokenGatedMajorMask", "AP_GetDistrictTokenGatedMajorMask", &APGetDistrictTokenGatedMajorMask);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictionType", "AP_GetWeaponRestrictionType", &APGetWeaponRestrictionType);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictPistol", "AP_GetWeaponRestrictPistol", &APGetWeaponRestrictPistol);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictMelee", "AP_GetWeaponRestrictMelee", &APGetWeaponRestrictMelee);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictRifle", "AP_GetWeaponRestrictRifle", &APGetWeaponRestrictRifle);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictSniper", "AP_GetWeaponRestrictSniper", &APGetWeaponRestrictSniper);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictLmg", "AP_GetWeaponRestrictLmg", &APGetWeaponRestrictLmg);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictShotgun", "AP_GetWeaponRestrictShotgun", &APGetWeaponRestrictShotgun);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictSmg", "AP_GetWeaponRestrictSmg", &APGetWeaponRestrictSmg);
     RegisterNative(rtti, "Archipelago.AP_GetVendorSanityEnabled", "AP_GetVendorSanityEnabled", &APGetVendorSanityEnabled);
     RegisterNative(rtti, "Archipelago.AP_GetVendorSanityStockLine", "AP_GetVendorSanityStockLine", &APGetVendorSanityStockLine);
     RegisterNative(rtti, "Archipelago.AP_GetDeathLinkEnabled", "AP_GetDeathLinkEnabled", &APGetDeathLinkEnabled);

--- a/worlds/cyberpunk2077/__init__.py
+++ b/worlds/cyberpunk2077/__init__.py
@@ -452,7 +452,7 @@ class Cyberpunk2077World(World):
         # This data is accessible to the game bridge via self.slot_data
         slot_data: Dict[str, Any] = {
             "world_version": 2,  # Version of your world implementation
-            # Configuration options sent to RedScript client via SYNC_CONFIG
+            # Configuration options sent to RedScript client via slot_data
             "death_link": bool(self.options.death_link.value),
             "death_link_amnesty": int(self.options.death_link_amnesty.value),
             # Weapon restriction settings


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR wires weapon restriction settings end-to-end from Archipelago `slot_data` into in-game enforcement, and fixes two RedScript edge cases that could make equips fail or make weapon passes not restore after sync/load.

## What changed
- Added native bridge support for weapon restriction `slot_data` keys (`weapon_restriction_type` and all `weapon_restrict_*` toggles) in `APBridge`.
- Exposed new RED4ext natives in `RedscriptAPI.cpp` and declared them in `APNativeBindings.reds`.
- Added `APGameState.SetWeaponRestrictionConfig(...)` plus `weaponRestrictionConfigInitialized`.
- Updated `TCPClient.Pump()` to mirror native weapon restriction values into `APGameState` and log when config changes.
- Fixed `APWeaponRestrictionEnforcer` equip hook to fail-open when the enforcer or item record is missing.
- Fixed weapon pass persistence by applying `HandleWeaponUnlock` during `HandleItemSync()` and `SyncData()`.
- Updated stale world comment in `fill_slot_data()` to reference `slot_data` instead of `SYNC_CONFIG`.

## Validation
- Attempted native rebuild in this cloud environment:
  - Existing Windows cache build dir (`native/build-test`) is not reusable here.
  - Fresh configure/build fails because the linker cannot find `-lstdc++` in this image.
- Environment limitations prevented a full local native build and in-game runtime verification.
- Performed consistency checks to confirm new key/native wiring exists across C++, native registrations, RedScript bindings, and `TCPClient` usage.

## Risk
- Low-to-moderate. Changes are targeted to config sync plumbing and existing item/equip branches.
- Main runtime behavior change is that weapon restrictions should now activate as configured from APWorld `slot_data` and weapon pass facts should reapply on sync/load.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25f0298b-0d7f-400a-ac57-bbdaa38a05bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25f0298b-0d7f-400a-ac57-bbdaa38a05bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

