### PR TITLE
Backport weapon restriction sync and pass persistence to v0.6

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
@@ -9,7 +9,7 @@ public class APGameState extends ScriptableService {
     public let enableDeathLink: Bool;
     public let restrictByMajorDistrict: Bool;
 
-    // Weapon restriction settings (synced from APWorld options via SYNC_CONFIG)
+    // Weapon restriction settings (synced from APWorld options via slot_data)
     // weaponRestrictionType: 0 = none, 1 = cannotEquip (hard ban), 2 = requireMultiworldItem (pass-gated)
     public let weaponRestrictionType: Int32;
     public let weaponRestrictPistol: Bool;
@@ -19,6 +19,7 @@ public class APGameState extends ScriptableService {
     public let weaponRestrictLmg: Bool;
     public let weaponRestrictShotgun: Bool;
     public let weaponRestrictSmg: Bool;
+    public let weaponRestrictionConfigInitialized: Bool;
 
     // Item tracking
     public let items: ref<APItemList>;
@@ -56,6 +57,46 @@ public class APGameState extends ScriptableService {
 
     public func SetRestrictByMajorDistrict(value: Bool) -> Void {
         this.restrictByMajorDistrict = value;
+    }
+
+    public func SetWeaponRestrictionConfig(
+        restrictionType: Int32,
+        restrictPistol: Bool,
+        restrictMelee: Bool,
+        restrictRifle: Bool,
+        restrictSniper: Bool,
+        restrictLmg: Bool,
+        restrictShotgun: Bool,
+        restrictSmg: Bool
+    ) -> Bool {
+        let changed: Bool = !this.weaponRestrictionConfigInitialized
+            || this.weaponRestrictionType < restrictionType
+            || this.weaponRestrictionType > restrictionType
+            || (this.weaponRestrictPistol && !restrictPistol)
+            || (!this.weaponRestrictPistol && restrictPistol)
+            || (this.weaponRestrictMelee && !restrictMelee)
+            || (!this.weaponRestrictMelee && restrictMelee)
+            || (this.weaponRestrictRifle && !restrictRifle)
+            || (!this.weaponRestrictRifle && restrictRifle)
+            || (this.weaponRestrictSniper && !restrictSniper)
+            || (!this.weaponRestrictSniper && restrictSniper)
+            || (this.weaponRestrictLmg && !restrictLmg)
+            || (!this.weaponRestrictLmg && restrictLmg)
+            || (this.weaponRestrictShotgun && !restrictShotgun)
+            || (!this.weaponRestrictShotgun && restrictShotgun)
+            || (this.weaponRestrictSmg && !restrictSmg)
+            || (!this.weaponRestrictSmg && restrictSmg);
+
+        this.weaponRestrictionType = restrictionType;
+        this.weaponRestrictPistol = restrictPistol;
+        this.weaponRestrictMelee = restrictMelee;
+        this.weaponRestrictRifle = restrictRifle;
+        this.weaponRestrictSniper = restrictSniper;
+        this.weaponRestrictLmg = restrictLmg;
+        this.weaponRestrictShotgun = restrictShotgun;
+        this.weaponRestrictSmg = restrictSmg;
+        this.weaponRestrictionConfigInitialized = true;
+        return changed;
     }
 
     public func HandlePlayerRespawn() -> Void {

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -88,6 +88,10 @@ public class APGameSystem extends ScriptableSystem {
                     // District unlock tokens (binary - just unlock)
                     this.HandleDistrictUnlock(item.itemID);
                 }
+                else if APItemParser.IsWeaponAuthorization(item.itemID) {
+                    // Weapon passes are quest-key style unlocks
+                    this.HandleWeaponUnlock(item.itemID);
+                }
                 else {
                     // Regular inventory items
                     this.inventoryHandler.GiveInventoryItem(item.itemID, difference);
@@ -257,6 +261,7 @@ public class APGameSystem extends ScriptableSystem {
         }
         else if APItemParser.IsWeaponAuthorization(item) {
             gameState.items.AddItem(item, 1);
+            this.HandleWeaponUnlock(item);
         }
         // Note: Skill points and traps not added as they're not fully implemented
     }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds
@@ -14,6 +14,14 @@ public static native func AP_IsDeathLinkPending() -> Bool
 public static native func AP_ClearDeathLink() -> Void
 public static native func AP_PollItemQueue() -> Int64
 public static native func AP_GetRestrictByMajorDistrict() -> Bool
+public static native func AP_GetWeaponRestrictionType() -> Int32
+public static native func AP_GetWeaponRestrictPistol() -> Bool
+public static native func AP_GetWeaponRestrictMelee() -> Bool
+public static native func AP_GetWeaponRestrictRifle() -> Bool
+public static native func AP_GetWeaponRestrictSniper() -> Bool
+public static native func AP_GetWeaponRestrictLmg() -> Bool
+public static native func AP_GetWeaponRestrictShotgun() -> Bool
+public static native func AP_GetWeaponRestrictSmg() -> Bool
 
 // Thin wrappers around the generated APArchipelagoIdMappings class.
 // The actual id <-> string tables live in APArchipelagoIdMappings.reds, which is

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
@@ -73,17 +73,25 @@ public class APWeaponRestrictionEnforcer extends ScriptableService {
 public final func EquipItem(itemId: ItemID, slot: Int32) -> Void {
     APLogger.LogDebug(s"Incoming Item equip attempt");
     let weaponEnforcer = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APWeaponRestrictionEnforcer") as APWeaponRestrictionEnforcer;
-    if IsDefined(weaponEnforcer) {
-        let incomingItem = itemId.GetTDBID();
-        let itemRecord: ref<Item_Record> = TweakDBInterface.GetItemRecord(incomingItem);
-        let itemType = itemRecord.ItemType().Type();
-        APLogger.LogDebug(s"Item Type is: \(itemType)");
-        if weaponEnforcer.CanEquipWeapon(itemType) {
-                APLogger.LogDebug("Weapon equip allowed");
-                wrappedMethod(itemId, slot); // Proceed with the equip action
-            } else {
-                APLogger.LogDebug("Weapon equip blocked by Archipelago restrictions");
-                return; // Block the equip action
-        }
+    if !IsDefined(weaponEnforcer) {
+        wrappedMethod(itemId, slot);
+        return;
+    }
+
+    let incomingItem = itemId.GetTDBID();
+    let itemRecord: ref<Item_Record> = TweakDBInterface.GetItemRecord(incomingItem);
+    if !IsDefined(itemRecord) {
+        wrappedMethod(itemId, slot);
+        return;
+    }
+
+    let itemType = itemRecord.ItemType().Type();
+    APLogger.LogDebug(s"Item Type is: \(itemType)");
+    if weaponEnforcer.CanEquipWeapon(itemType) {
+        APLogger.LogDebug("Weapon equip allowed");
+        wrappedMethod(itemId, slot); // Proceed with the equip action
+    } else {
+        APLogger.LogDebug("Weapon equip blocked by Archipelago restrictions");
+        return; // Block the equip action
     }
 }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -142,6 +142,21 @@ public class TCPClient extends ScriptableService {
             let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
             if IsDefined(gameState) {
                 gameState.SetRestrictByMajorDistrict(AP_GetRestrictByMajorDistrict());
+                let weaponConfigChanged: Bool = gameState.SetWeaponRestrictionConfig(
+                    AP_GetWeaponRestrictionType(),
+                    AP_GetWeaponRestrictPistol(),
+                    AP_GetWeaponRestrictMelee(),
+                    AP_GetWeaponRestrictRifle(),
+                    AP_GetWeaponRestrictSniper(),
+                    AP_GetWeaponRestrictLmg(),
+                    AP_GetWeaponRestrictShotgun(),
+                    AP_GetWeaponRestrictSmg()
+                );
+                if weaponConfigChanged {
+                    APLogger.LogInfo(
+                        s"Weapon restriction config received: type=\(ToString(gameState.weaponRestrictionType)), pistol=\(gameState.weaponRestrictPistol), melee=\(gameState.weaponRestrictMelee), rifle=\(gameState.weaponRestrictRifle), sniper=\(gameState.weaponRestrictSniper), lmg=\(gameState.weaponRestrictLmg), shotgun=\(gameState.weaponRestrictShotgun), smg=\(gameState.weaponRestrictSmg)"
+                    );
+                }
             }
         }
 

--- a/native/cyberpunk_ap_plugin/src/APBridge.cpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.cpp
@@ -31,6 +31,14 @@ bool APBridge::Initialize(const std::string& serverAddress,
     AP_SetDeathLinkSupported(true);
     AP_SetDeathLinkRecvCallback(&APBridge::OnDeathLinkReceived);
     AP_RegisterSlotDataIntCallback("restrict_by_major_district", &APBridge::OnSlotDataRestrictByMajorDistrict);
+    AP_RegisterSlotDataIntCallback("weapon_restriction_type", &APBridge::OnSlotDataWeaponRestrictionType);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_pistol", &APBridge::OnSlotDataWeaponRestrictPistol);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_melee", &APBridge::OnSlotDataWeaponRestrictMelee);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_rifle", &APBridge::OnSlotDataWeaponRestrictRifle);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_sniper", &APBridge::OnSlotDataWeaponRestrictSniper);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_lmg", &APBridge::OnSlotDataWeaponRestrictLmg);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_shotgun", &APBridge::OnSlotDataWeaponRestrictShotgun);
+    AP_RegisterSlotDataIntCallback("weapon_restrict_smg", &APBridge::OnSlotDataWeaponRestrictSmg);
 
     // AP_Init() is void and has no synchronous failure path; AP_IsInit() only
     // returns true after AP_Start() is called, so we track init state ourselves.
@@ -70,6 +78,14 @@ void APBridge::Shutdown()
     m_started = false;
     m_deathLinkPending = false;
     m_restrictByMajorDistrict = false;
+    m_weaponRestrictionType = 0;
+    m_weaponRestrictPistol = false;
+    m_weaponRestrictMelee = false;
+    m_weaponRestrictRifle = false;
+    m_weaponRestrictSniper = false;
+    m_weaponRestrictLmg = false;
+    m_weaponRestrictShotgun = false;
+    m_weaponRestrictSmg = false;
     std::queue<int64_t> empty;
     m_receivedItemIds.swap(empty);
 }
@@ -184,6 +200,54 @@ bool APBridge::GetRestrictByMajorDistrict() const
     return m_restrictByMajorDistrict;
 }
 
+int32_t APBridge::GetWeaponRestrictionType() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictionType;
+}
+
+bool APBridge::GetWeaponRestrictPistol() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictPistol;
+}
+
+bool APBridge::GetWeaponRestrictMelee() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictMelee;
+}
+
+bool APBridge::GetWeaponRestrictRifle() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictRifle;
+}
+
+bool APBridge::GetWeaponRestrictSniper() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictSniper;
+}
+
+bool APBridge::GetWeaponRestrictLmg() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictLmg;
+}
+
+bool APBridge::GetWeaponRestrictShotgun() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictShotgun;
+}
+
+bool APBridge::GetWeaponRestrictSmg() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_weaponRestrictSmg;
+}
+
 void APBridge::OnItemClear()
 {
     std::lock_guard<std::mutex> lock(APBridge::Get().m_mutex);
@@ -210,6 +274,46 @@ void APBridge::OnSlotDataRestrictByMajorDistrict(int value)
     APBridge::Get().SetRestrictByMajorDistrict(value != 0);
 }
 
+void APBridge::OnSlotDataWeaponRestrictionType(int value)
+{
+    APBridge::Get().SetWeaponRestrictionType(value);
+}
+
+void APBridge::OnSlotDataWeaponRestrictPistol(int value)
+{
+    APBridge::Get().SetWeaponRestrictPistol(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictMelee(int value)
+{
+    APBridge::Get().SetWeaponRestrictMelee(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictRifle(int value)
+{
+    APBridge::Get().SetWeaponRestrictRifle(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictSniper(int value)
+{
+    APBridge::Get().SetWeaponRestrictSniper(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictLmg(int value)
+{
+    APBridge::Get().SetWeaponRestrictLmg(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictShotgun(int value)
+{
+    APBridge::Get().SetWeaponRestrictShotgun(value != 0);
+}
+
+void APBridge::OnSlotDataWeaponRestrictSmg(int value)
+{
+    APBridge::Get().SetWeaponRestrictSmg(value != 0);
+}
+
 void APBridge::PushItem(int64_t itemId)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -226,5 +330,53 @@ void APBridge::SetRestrictByMajorDistrict(bool value)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_restrictByMajorDistrict = value;
+}
+
+void APBridge::SetWeaponRestrictionType(int32_t value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictionType = value;
+}
+
+void APBridge::SetWeaponRestrictPistol(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictPistol = value;
+}
+
+void APBridge::SetWeaponRestrictMelee(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictMelee = value;
+}
+
+void APBridge::SetWeaponRestrictRifle(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictRifle = value;
+}
+
+void APBridge::SetWeaponRestrictSniper(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictSniper = value;
+}
+
+void APBridge::SetWeaponRestrictLmg(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictLmg = value;
+}
+
+void APBridge::SetWeaponRestrictShotgun(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictShotgun = value;
+}
+
+void APBridge::SetWeaponRestrictSmg(bool value)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_weaponRestrictSmg = value;
 }
 } // namespace CyberpunkArchipelago

--- a/native/cyberpunk_ap_plugin/src/APBridge.hpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.hpp
@@ -35,6 +35,14 @@ public:
     void ClearDeathLink();
 
     bool GetRestrictByMajorDistrict() const;
+    int32_t GetWeaponRestrictionType() const;
+    bool GetWeaponRestrictPistol() const;
+    bool GetWeaponRestrictMelee() const;
+    bool GetWeaponRestrictRifle() const;
+    bool GetWeaponRestrictSniper() const;
+    bool GetWeaponRestrictLmg() const;
+    bool GetWeaponRestrictShotgun() const;
+    bool GetWeaponRestrictSmg() const;
 
 private:
     APBridge() = default;
@@ -46,18 +54,42 @@ private:
     static void OnLocationChecked(int64_t locationId);
     static void OnDeathLinkReceived();
     static void OnSlotDataRestrictByMajorDistrict(int value);
+    static void OnSlotDataWeaponRestrictionType(int value);
+    static void OnSlotDataWeaponRestrictPistol(int value);
+    static void OnSlotDataWeaponRestrictMelee(int value);
+    static void OnSlotDataWeaponRestrictRifle(int value);
+    static void OnSlotDataWeaponRestrictSniper(int value);
+    static void OnSlotDataWeaponRestrictLmg(int value);
+    static void OnSlotDataWeaponRestrictShotgun(int value);
+    static void OnSlotDataWeaponRestrictSmg(int value);
 
     bool IsReadyLocked() const; // caller must hold m_mutex
 
     void PushItem(int64_t itemId);
     void MarkDeathLinkPending();
     void SetRestrictByMajorDistrict(bool value);
+    void SetWeaponRestrictionType(int32_t value);
+    void SetWeaponRestrictPistol(bool value);
+    void SetWeaponRestrictMelee(bool value);
+    void SetWeaponRestrictRifle(bool value);
+    void SetWeaponRestrictSniper(bool value);
+    void SetWeaponRestrictLmg(bool value);
+    void SetWeaponRestrictShotgun(bool value);
+    void SetWeaponRestrictSmg(bool value);
 
     mutable std::mutex m_mutex;
     bool m_initialized{false};
     bool m_started{false};
     bool m_deathLinkPending{false};
     bool m_restrictByMajorDistrict{false};
+    int32_t m_weaponRestrictionType{0};
+    bool m_weaponRestrictPistol{false};
+    bool m_weaponRestrictMelee{false};
+    bool m_weaponRestrictRifle{false};
+    bool m_weaponRestrictSniper{false};
+    bool m_weaponRestrictLmg{false};
+    bool m_weaponRestrictShotgun{false};
+    bool m_weaponRestrictSmg{false};
     std::queue<int64_t> m_receivedItemIds;
 };
 } // namespace CyberpunkArchipelago

--- a/native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp
+++ b/native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp
@@ -147,6 +147,78 @@ void APGetRestrictByMajorDistrict(RED4ext::IScriptable*, RED4ext::CStackFrame* a
     }
 }
 
+void APGetWeaponRestrictionType(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictionType();
+    }
+}
+
+void APGetWeaponRestrictPistol(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictPistol();
+    }
+}
+
+void APGetWeaponRestrictMelee(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictMelee();
+    }
+}
+
+void APGetWeaponRestrictRifle(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictRifle();
+    }
+}
+
+void APGetWeaponRestrictSniper(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictSniper();
+    }
+}
+
+void APGetWeaponRestrictLmg(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictLmg();
+    }
+}
+
+void APGetWeaponRestrictShotgun(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictShotgun();
+    }
+}
+
+void APGetWeaponRestrictSmg(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetWeaponRestrictSmg();
+    }
+}
+
 template <typename TFunc>
 void RegisterNative(RED4ext::CRTTISystem* rtti, const char* fullName, const char* shortName, TFunc fn)
 {
@@ -185,6 +257,14 @@ void PostRegisterTypes()
     RegisterNative(rtti, "Archipelago.AP_ClearDeathLink", "AP_ClearDeathLink", &APClearDeathLink);
     RegisterNative(rtti, "Archipelago.AP_PollItemQueue", "AP_PollItemQueue", &APPollItemQueue);
     RegisterNative(rtti, "Archipelago.AP_GetRestrictByMajorDistrict", "AP_GetRestrictByMajorDistrict", &APGetRestrictByMajorDistrict);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictionType", "AP_GetWeaponRestrictionType", &APGetWeaponRestrictionType);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictPistol", "AP_GetWeaponRestrictPistol", &APGetWeaponRestrictPistol);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictMelee", "AP_GetWeaponRestrictMelee", &APGetWeaponRestrictMelee);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictRifle", "AP_GetWeaponRestrictRifle", &APGetWeaponRestrictRifle);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictSniper", "AP_GetWeaponRestrictSniper", &APGetWeaponRestrictSniper);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictLmg", "AP_GetWeaponRestrictLmg", &APGetWeaponRestrictLmg);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictShotgun", "AP_GetWeaponRestrictShotgun", &APGetWeaponRestrictShotgun);
+    RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictSmg", "AP_GetWeaponRestrictSmg", &APGetWeaponRestrictSmg);
 
     if (g_sdk && g_sdk->logger)
     {

--- a/worlds/cyberpunk2077/__init__.py
+++ b/worlds/cyberpunk2077/__init__.py
@@ -351,7 +351,7 @@ class Cyberpunk2077World(World):
         # This data is accessible to the game bridge via self.slot_data
         slot_data: Dict[str, Any] = {
             "world_version": 1,  # Version of your world implementation
-            # Configuration options sent to RedScript client via SYNC_CONFIG
+            # Configuration options sent to RedScript client via slot_data
             "death_link": bool(self.options.death_link.value),
             # Weapon restriction settings
             # 0 = none (no restriction), 1 = cannotEquip (hard ban), 2 = requireMultiworldItem (pass-gated)

--- a/worlds/cyberpunk2077/archipelago.json
+++ b/worlds/cyberpunk2077/archipelago.json
@@ -2,5 +2,5 @@
   "game": "Cyberpunk 2077",
   "authors": ["247Tossing"],
   "minimum_ap_version": "0.6.6",
-  "world_version": "0.6.0"
+  "world_version": "0.6.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Backported weapon restriction slot-data wiring from APWorld to the native bridge and RedScript bindings.
- Synced weapon restriction config into `APGameState` during `TCPClient.Pump()` so equip enforcement receives live settings.
- Restored weapon pass unlock behavior during sync/reload paths (`SyncData` and `HandleItemSync`).
- Hardened `APWeaponRestrictionEnforcer.EquipItem` to fail open when the enforcer or item record is unavailable.
- Updated APWorld slot-data comment wording and bumped `world_version` to `0.6.1`.

## Files changed
- `native/cyberpunk_ap_plugin/src/APBridge.hpp`
- `native/cyberpunk_ap_plugin/src/APBridge.cpp`
- `native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds`
- `worlds/cyberpunk2077/__init__.py`
- `worlds/cyberpunk2077/archipelago.json`

## Validation
- `python3 -m compileall worlds/cyberpunk2077`
- `python3 tools/build_release.py` (fails in this environment because `/usr/bin/ld` cannot find `-lstdc++`)
- `python3 tools/build_release.py --skip-native --skip-submodules --archipelago-root /workspace/Archipelago` (succeeds; produces `cyberpunk2077.apworld`, PopTracker zip, and mod zip)

## Release notes
- Tagged and pushed `v0.6.1` on the backport commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7676dca0-61a1-44d4-8be1-d945a8c3cd66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7676dca0-61a1-44d4-8be1-d945a8c3cd66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

