### PR TITLE
Hide vendor check items when vendor sanity is disabled

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
@@ -14,6 +14,7 @@ public class APGameState extends ScriptableService {
     public let vendorSanityEnabled: Bool;
     public let vendorSanityStockLine: String;
     public let vendorSanityItems: array<ref<APVendorItem>>;
+    public let vendorSanityConfigInitialized: Bool;
 
     // Weapon restriction settings (synced from APWorld options via slot_data)
     // weaponRestrictionType: 0 = none, 1 = cannotEquip (hard ban), 2 = requireMultiworldItem (pass-gated)
@@ -88,13 +89,15 @@ public class APGameState extends ScriptableService {
     }
 
     public func SetVendorSanityData(enabled: Bool, stockLine: String) -> Bool {
-        let changed: Bool = (this.vendorSanityEnabled && !enabled)
+        let changed: Bool = !this.vendorSanityConfigInitialized
+            || (this.vendorSanityEnabled && !enabled)
             || (!this.vendorSanityEnabled && enabled)
             || StrCmp(this.vendorSanityStockLine, stockLine) != 0;
 
         this.vendorSanityEnabled = enabled;
         this.vendorSanityStockLine = stockLine;
         this.vendorSanityItems = APVendorItem.ParseStockLine(stockLine);
+        this.vendorSanityConfigInitialized = true;
         if changed {
             this.LogVendorSanitySlotDataDebug();
         }
@@ -300,6 +303,16 @@ public class APGameState extends ScriptableService {
             i += 1;
         }
         return false;
+    }
+
+    public func ShouldShowVendorCheckInInventory(locationId: String) -> Bool {
+        if !this.vendorSanityConfigInitialized {
+            return true;
+        }
+        if !this.vendorSanityEnabled {
+            return false;
+        }
+        return this.IsVendorCheckInRun(locationId);
     }
 
     public func HandlePlayerRespawn() -> Void {

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APVendorStockCleaner.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APVendorStockCleaner.reds
@@ -7,10 +7,9 @@ module Archipelago
 // "Already checked" is detected via the ap_VendorCheck_* quest facts written by
 // APVendorTransactionReader on purchase — no additional state is introduced.
 //
-// "Disabled category" is detected by checking whether the locationId appears in the
-// vendorSanityItems list (vendor_sanity_stock from slot_data). Items from vendor
-// categories that were not enabled for this seed are absent from that list and will
-// be removed from the live inventory so they never appear in the vendor UI.
+// "Disabled category/option" is detected by checking slot_data through APGameState:
+// if vendor_sanity is off, all VendorCheck_* items are hidden; if it is on, only
+// checks present in vendor_sanity_stock stay visible.
 
 @addMethod(FullscreenVendorGameController)
 private func APCleanCheckedVendorItems() -> Void {
@@ -60,10 +59,11 @@ private func APCleanCheckedVendorItems() -> Void {
                 shouldRemove = true;
             }
 
-            // Remove if connected and this check is not part of the active run's vendor stock
-            // (covers disabled sub-categories and checks not assigned to any vendor this seed)
-            if !shouldRemove && isConnected && IsDefined(gameState) && gameState.vendorSanityEnabled {
-                if !gameState.IsVendorCheckInRun(locationId) {
+            // Remove if connected and slot_data says this check should not be visible.
+            // This covers vendor_sanity disabled, disabled sub-categories, and checks
+            // not assigned to any vendor in this seed.
+            if !shouldRemove && isConnected && IsDefined(gameState) && gameState.vendorSanityConfigInitialized {
+                if !gameState.ShouldShowVendorCheckInInventory(locationId) {
                     shouldRemove = true;
                 }
             }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APVendorTransactionReader.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APVendorTransactionReader.reds
@@ -24,9 +24,23 @@ public final func BuyItemFromVendor(item: wref<gameItemData>, quantity: Int32, o
 
     if StrLen(locationId) > 0 {
         APLogger.LogDebug(s"Buying VendorCheck item:\(locationId)");
-        let questSystem: ref<QuestsSystem> = GameInstance.GetQuestsSystem(GetGameInstance()) as QuestsSystem;
-        let tcpService: ref<TCPClient> = GameInstance.GetScriptableServiceContainer().GetService(APConstants.GetTCPClientName()) as TCPClient;
-        APQuestLocationLookup.SendLocationCheck(questSystem, tcpService, locationId);
+        let shouldSendCheck: Bool = false;
+        let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(APConstants.GetAPGameStateName()) as APGameState;
+        if AP_IsConnected()
+            && IsDefined(gameState)
+            && gameState.vendorSanityConfigInitialized
+            && gameState.vendorSanityEnabled
+            && gameState.ShouldShowVendorCheckInInventory(locationId) {
+            shouldSendCheck = true;
+        }
+
+        if shouldSendCheck {
+            let questSystem: ref<QuestsSystem> = GameInstance.GetQuestsSystem(GetGameInstance()) as QuestsSystem;
+            let tcpService: ref<TCPClient> = GameInstance.GetScriptableServiceContainer().GetService(APConstants.GetTCPClientName()) as TCPClient;
+            APQuestLocationLookup.SendLocationCheck(questSystem, tcpService, locationId);
+        } else {
+            APLogger.LogDebug(s"Skipping VendorCheck send for inactive location: \(locationId)");
+        }
 
         wrappedMethod(item, quantity, requestId);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes vendor `VendorCheck_*` items appearing in vendor inventories when the `vendor_sanity` world option is disabled.

TweakXL always injects vendor check items into vendor stock. Python generation and slot_data already send `vendor_sanity: 0` when the option is off, but the runtime stock cleaner only filtered items when vendor sanity was enabled. This wires up the existing disabled path so all vendor checks are hidden when the option is off.

## Changes

- Add `vendorSanityConfigInitialized` to `APGameState` so slot_data must sync before filtering runs (avoids treating the default false state as "disabled" before connect).
- Add `ShouldShowVendorCheckInInventory()` to centralize visibility rules:
  - not yet synced: show (no filtering)
  - `vendor_sanity` off: hide all checks
  - `vendor_sanity` on: show only checks in `vendor_sanity_stock`
- Update `APVendorStockCleaner` to use the shared visibility helper instead of only filtering when `vendorSanityEnabled` is true.
- Gate `APVendorTransactionReader` location-check sends so inactive/disabled vendor checks cannot emit AP checks.

## Files changed

- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APVendorStockCleaner.reds`
- `Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APVendorTransactionReader.reds`

## Validation

- RedScript-only change; no native/DLL rebuild required.
- In-game: connect to a seed with `vendor_sanity` off, open a vendor after slot_data sync, and confirm no `VendorCheck_*` items appear.
- In-game: connect with `vendor_sanity` on and confirm only active stock rows remain visible and purchases still send checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c9f5877-94bb-4e65-b0ad-7665c84eebb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c9f5877-94bb-4e65-b0ad-7665c84eebb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

