### PR TITLE
Hotfix: stop trap replay and district-token loss on reconnect

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APConstants.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APConstants.reds
@@ -154,6 +154,11 @@ public class APConstants {
     public static func GetTarotCounterFact() -> String { return "mq033_grafitti_counter"; }
     public static func GetVPillsFact() -> String { return "q101_v_reached_pills"; }
 
+    // Persists how many network items (by server-stream index) have already been applied via a live
+    // grant, so reconnects can distinguish "new item" from "already-applied item being resent" and
+    // avoid re-triggering one-shot effects (e.g. traps) or duplicate grants.
+    public static func GetNetworkItemIndexFact() -> String { return "ap_network_item_index"; }
+
     // ===== SERVICE NAMES =====
     // CNames for retrieving services from the game engine
     public static func GetAPGameSystemName() -> CName { return n"Archipelago.APGameSystem"; }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
@@ -40,8 +40,15 @@ public class APDistrictManager extends ScriptableSystem {
             APLogger.LogDebug("APDistrictManager: Quest handler not initialized");
             return;
         }
-        this.questHandler.SetQuestKey(districtId);
-        APLogger.LogInfo(s"District unlocked: \(districtId)");
+
+        // Only report success when the quest fact write actually succeeded - previously this logged
+        // "District unlocked" unconditionally, which was misleading when SetQuestKey failed (e.g. the
+        // quest system wasn't available yet), leaving the district silently still locked.
+        if this.questHandler.SetQuestKey(districtId) {
+            APLogger.LogInfo(s"District unlocked: \(districtId)");
+        } else {
+            APLogger.LogError(s"APDistrictManager: Failed to unlock district \(districtId) - quest system not available");
+        }
     }
 
     // Handle district restriction (called when player enters locked district)

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -229,7 +229,16 @@ public class APGameSystem extends ScriptableSystem {
         }
     }
 
-    private func HandleItemSync(item: String, gameState: ref<APGameState>) -> Void {
+    // Re-applies an already-seen network item (i.e. one the server is resending on reconnect that
+    // was already applied during a prior connection). This must never re-trigger one-shot effects
+    // like traps, but progression state (quest keys, district tokens, weapon passes) is safe - and
+    // necessary - to reconcile here, since it recovers grants that never made it into a quest fact
+    // the first time (e.g. the item arrived before the world/quest system was ready).
+    public func HandleItemSync(item: String, gameState: ref<APGameState>) -> Void {
+        if !IsDefined(gameState) || !IsDefined(gameState.items) {
+            return;
+        }
+
         if !APItemParser.IsValidAPItem(item) {
             return;
         }
@@ -242,6 +251,10 @@ public class APGameSystem extends ScriptableSystem {
             // Quest keys are tracked even though they're binary (0 or 1)
             gameState.items.AddItem(item, 1);
             this.AddQuestKey(item);
+        }
+        else if APItemParser.IsTrap(item) {
+            // Traps are one-shot effects - re-syncing a previously-applied item must not re-trigger them.
+            APLogger.LogDebug(s"APGameSystem: Skipping trap replay during sync: \(item)");
         }
         else if APItemParser.IsEddies(item) {
             let amount: Int32 = APItemParser.ParseEddiesAmount(item);
@@ -256,14 +269,16 @@ public class APGameSystem extends ScriptableSystem {
             gameState.items.AddItem(item, 1);
         }
         else if APItemParser.IsDistrictToken(item) {
-            // Track district tokens so they can be re-synced on save load
+            // Track district tokens so they can be re-synced on save load, and retry the unlock in
+            // case the quest fact never got written the first time this item was received.
             gameState.items.AddItem(item, 1);
+            this.HandleDistrictUnlock(item);
         }
         else if APItemParser.IsWeaponAuthorization(item) {
             gameState.items.AddItem(item, 1);
             this.HandleWeaponUnlock(item);
         }
-        // Note: Skill points and traps not added as they're not fully implemented
+        // Note: Skill points not added as they're not fully implemented
     }
 
     public func HandleItemReceived(item: String) -> Void {

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APInventoryHandler.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APInventoryHandler.reds
@@ -77,4 +77,17 @@ public class APInventoryHandler extends ScriptableSystem {
         let currentCount: Int32 = this.GetItemFactCount(itemId);
         this.UpdateItemFact(itemId, currentCount + incrementBy);
     }
+
+    // Last network item index (server ReceivedItems stream position) that was applied via a live
+    // grant. Persisted as a quest fact so it survives save/reload and reconnects.
+    public func GetLastNetworkItemIndex() -> Int32 {
+        return this.GetItemFactCount(APConstants.GetNetworkItemIndexFact());
+    }
+
+    public func SetLastNetworkItemIndex(newIndex: Int32) -> Void {
+        if newIndex < 0 {
+            newIndex = 0;
+        }
+        this.UpdateItemFact(APConstants.GetNetworkItemIndexFact(), newIndex);
+    }
 }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APNativeBindings.reds
@@ -13,6 +13,11 @@ public static native func AP_StoryComplete() -> Bool
 public static native func AP_IsDeathLinkPending() -> Bool
 public static native func AP_ClearDeathLink() -> Void
 public static native func AP_PollItemQueue() -> Int64
+// Valid only immediately after a successful AP_PollItemQueue() call that returned a real item id.
+// Identifies the item's position in the server's ReceivedItems stream so callers can detect items
+// already applied on a prior connection and avoid re-applying one-shot effects (e.g. traps).
+public static native func AP_GetPolledItemNetworkIndex() -> Int32
+public static native func AP_GetPolledItemShouldNotify() -> Bool
 public static native func AP_GetRestrictByMajorDistrict() -> Bool
 public static native func AP_GetWeaponRestrictionType() -> Int32
 public static native func AP_GetWeaponRestrictPistol() -> Bool

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -162,16 +162,46 @@ public class TCPClient extends ScriptableService {
 
         // Poll item queue from APCpp.
         // Item ID -> in-game mapping is handled in RedScript via APNativeMappings.ResolveItemId.
-        let nextItemId: Int64 = AP_PollItemQueue();
-        if nextItemId >= 0l {
-            let itemId: String = APNativeMappings.ResolveItemId(nextItemId);
-            if StrLen(itemId) > 0 {
-                let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
-                if IsDefined(gameSystem) {
-                    gameSystem.HandleItemReceived(itemId);
+        //
+        // Only poll while APGameSystem is available (i.e. a save is loaded). Polling from the main
+        // menu or before the world is ready would pop the item off the native queue with nowhere to
+        // apply it, permanently losing it even though the server considers it delivered. Leaving it
+        // queued here means it's applied as soon as a save is loaded and Pump runs again.
+        let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+        if IsDefined(gameSystem) {
+            let nextItemId: Int64 = AP_PollItemQueue();
+            if nextItemId >= 0l {
+                let itemId: String = APNativeMappings.ResolveItemId(nextItemId);
+                if StrLen(itemId) > 0 {
+                    let networkIndex: Int32 = AP_GetPolledItemNetworkIndex();
+                    let inventoryHandler: ref<APInventoryHandler> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APInventoryHandler") as APInventoryHandler;
+                    let shouldGrant: Bool = true;
+
+                    // If this item's network index is older than the last one we already applied
+                    // live, the server is resending something we've already processed (typically on
+                    // reconnect). Route it through the sync path instead of granting it again, so
+                    // one-shot effects (traps) don't replay and inventory/eddies aren't duplicated -
+                    // while still letting durable state (quest keys, district tokens) reconcile.
+                    if networkIndex >= 0 && IsDefined(inventoryHandler) {
+                        let lastProcessedIndex: Int32 = inventoryHandler.GetLastNetworkItemIndex();
+                        if networkIndex < lastProcessedIndex {
+                            shouldGrant = false;
+                            let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+                            if IsDefined(gameState) {
+                                gameSystem.HandleItemSync(itemId, gameState);
+                            }
+                        }
+                    }
+
+                    if shouldGrant {
+                        gameSystem.HandleItemReceived(itemId);
+                        if networkIndex >= 0 && IsDefined(inventoryHandler) {
+                            inventoryHandler.SetLastNetworkItemIndex(networkIndex + 1);
+                        }
+                    }
+                } else {
+                    APLogger.LogDebug(s"TCPClient: No item mapping for AP item ID \(ToString(nextItemId))");
                 }
-            } else {
-                APLogger.LogDebug(s"TCPClient: No item mapping for AP item ID \(ToString(nextItemId))");
             }
         }
 

--- a/native/APCpp/Archipelago.cpp
+++ b/native/APCpp/Archipelago.cpp
@@ -69,7 +69,7 @@ std::set<int> teams_set;
 
 // Callback function pointers
 std::function<void()> resetItemValues = nullptr;
-std::function<void(int64_t,bool)> getitemfunc = nullptr;
+std::function<void(int64_t,bool,int32_t)> getitemfunc = nullptr;
 std::function<void(int64_t)> checklocfunc = nullptr;
 std::function<void(std::vector<AP_NetworkItem>)> locinfofunc = nullptr;
 std::function<void(std::string, std::string)> recvdeath = nullptr;
@@ -446,7 +446,7 @@ void AP_SetItemClearCallback(std::function<void()> f_itemclr) {
     resetItemValues = f_itemclr;
 }
 
-void AP_SetItemRecvCallback(std::function<void(int64_t,bool)> f_itemrecv) {
+void AP_SetItemRecvCallback(std::function<void(int64_t,bool,int32_t)> f_itemrecv) {
     getitemfunc = f_itemrecv;
 }
 
@@ -991,7 +991,8 @@ bool parse_response(std::string msg, std::string &request) {
             for (unsigned int j = 0; j < root[i]["items"].size(); j++) {
                 int64_t item_id = root[i]["items"][j]["item"].asInt64();
                 notify = (item_idx == 0 && last_item_idx <= j && multiworld) || item_idx != 0;
-                getitemfunc(item_id, notify);
+                int32_t network_index = item_idx + static_cast<int32_t>(j);
+                getitemfunc(item_id, notify, network_index);
                 if (queueitemrecvmsg && notify) {
                     AP_ItemRecvMessage* msg = new AP_ItemRecvMessage;
                     AP_NetworkPlayer sender = getPlayer(0, root[i]["items"][j]["player"].asInt());

--- a/native/APCpp/Archipelago.h
+++ b/native/APCpp/Archipelago.h
@@ -53,8 +53,10 @@ void AP_SetDeathLinkSupported(bool);
 
 //Parameter Function must reset local state
 void AP_SetItemClearCallback(std::function<void()> f_itemclr);
-//Parameter Function must collect item id given with parameter. Secound parameter indicates whether or not to notify player
-void AP_SetItemRecvCallback(std::function<void(int64_t,bool)> f_itemrecv);
+//Parameter Function must collect item id given with parameter. Second parameter indicates whether or not to notify player.
+//Third parameter is the network item index (position in the server's ReceivedItems stream), used by callers to
+//detect and skip re-application of items already applied on a prior connection (e.g. traps, duplicate grants).
+void AP_SetItemRecvCallback(std::function<void(int64_t,bool,int32_t)> f_itemrecv);
 //Parameter Function must mark given location id as checked
 void AP_SetLocationCheckedCallback(std::function<void(int64_t)> f_locrecv);
 

--- a/native/cyberpunk_ap_plugin/src/APBridge.cpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.cpp
@@ -86,8 +86,10 @@ void APBridge::Shutdown()
     m_weaponRestrictLmg = false;
     m_weaponRestrictShotgun = false;
     m_weaponRestrictSmg = false;
-    std::queue<int64_t> empty;
+    std::queue<ReceivedItemEntry> empty;
     m_receivedItemIds.swap(empty);
+    m_lastPolledNetworkIndex = -1;
+    m_lastPolledShouldNotify = false;
 }
 
 bool APBridge::IsReady() const
@@ -168,14 +170,31 @@ bool APBridge::StoryComplete()
 bool APBridge::PollReceivedItemId(int64_t& outItemId)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
+    m_lastPolledNetworkIndex = -1;
+    m_lastPolledShouldNotify = false;
     if (m_receivedItemIds.empty())
     {
         return false;
     }
 
-    outItemId = m_receivedItemIds.front();
+    const ReceivedItemEntry entry = m_receivedItemIds.front();
     m_receivedItemIds.pop();
+    outItemId = entry.itemId;
+    m_lastPolledNetworkIndex = entry.networkIndex;
+    m_lastPolledShouldNotify = entry.shouldNotify;
     return true;
+}
+
+int32_t APBridge::GetPolledItemNetworkIndex() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_lastPolledNetworkIndex;
+}
+
+bool APBridge::GetPolledItemShouldNotify() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_lastPolledShouldNotify;
 }
 
 bool APBridge::IsDeathLinkPending() const
@@ -251,13 +270,15 @@ bool APBridge::GetWeaponRestrictSmg() const
 void APBridge::OnItemClear()
 {
     std::lock_guard<std::mutex> lock(APBridge::Get().m_mutex);
-    std::queue<int64_t> empty;
+    std::queue<ReceivedItemEntry> empty;
     APBridge::Get().m_receivedItemIds.swap(empty);
+    APBridge::Get().m_lastPolledNetworkIndex = -1;
+    APBridge::Get().m_lastPolledShouldNotify = false;
 }
 
-void APBridge::OnItemReceived(int64_t itemId, bool)
+void APBridge::OnItemReceived(int64_t itemId, bool notify, int32_t networkIndex)
 {
-    APBridge::Get().PushItem(itemId);
+    APBridge::Get().PushItem(itemId, networkIndex, notify);
 }
 
 void APBridge::OnLocationChecked(int64_t)
@@ -314,10 +335,10 @@ void APBridge::OnSlotDataWeaponRestrictSmg(int value)
     APBridge::Get().SetWeaponRestrictSmg(value != 0);
 }
 
-void APBridge::PushItem(int64_t itemId)
+void APBridge::PushItem(int64_t itemId, int32_t networkIndex, bool shouldNotify)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_receivedItemIds.push(itemId);
+    m_receivedItemIds.push({itemId, networkIndex, shouldNotify});
 }
 
 void APBridge::MarkDeathLinkPending()

--- a/native/cyberpunk_ap_plugin/src/APBridge.hpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.hpp
@@ -9,6 +9,16 @@
 
 namespace CyberpunkArchipelago
 {
+// One entry from the server's ReceivedItems stream. networkIndex is the item's position in that
+// stream and is used to detect items that were already applied on a prior connection (so callers
+// can skip re-applying one-shot effects like traps, while still reconciling durable state).
+struct ReceivedItemEntry
+{
+    int64_t itemId{0};
+    int32_t networkIndex{-1};
+    bool shouldNotify{false};
+};
+
 class APBridge
 {
 public:
@@ -31,6 +41,8 @@ public:
     bool StoryComplete();
 
     bool PollReceivedItemId(int64_t& outItemId);
+    int32_t GetPolledItemNetworkIndex() const;
+    bool GetPolledItemShouldNotify() const;
     bool IsDeathLinkPending() const;
     void ClearDeathLink();
 
@@ -50,7 +62,7 @@ private:
     APBridge& operator=(const APBridge&) = delete;
 
     static void OnItemClear();
-    static void OnItemReceived(int64_t itemId, bool notify);
+    static void OnItemReceived(int64_t itemId, bool notify, int32_t networkIndex);
     static void OnLocationChecked(int64_t locationId);
     static void OnDeathLinkReceived();
     static void OnSlotDataRestrictByMajorDistrict(int value);
@@ -65,7 +77,7 @@ private:
 
     bool IsReadyLocked() const; // caller must hold m_mutex
 
-    void PushItem(int64_t itemId);
+    void PushItem(int64_t itemId, int32_t networkIndex, bool shouldNotify);
     void MarkDeathLinkPending();
     void SetRestrictByMajorDistrict(bool value);
     void SetWeaponRestrictionType(int32_t value);
@@ -90,6 +102,8 @@ private:
     bool m_weaponRestrictLmg{false};
     bool m_weaponRestrictShotgun{false};
     bool m_weaponRestrictSmg{false};
-    std::queue<int64_t> m_receivedItemIds;
+    std::queue<ReceivedItemEntry> m_receivedItemIds;
+    int32_t m_lastPolledNetworkIndex{-1};
+    bool m_lastPolledShouldNotify{false};
 };
 } // namespace CyberpunkArchipelago

--- a/native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp
+++ b/native/cyberpunk_ap_plugin/src/RedscriptAPI.cpp
@@ -138,6 +138,24 @@ void APPollItemQueue(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int64_
     }
 }
 
+void APGetPolledItemNetworkIndex(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetPolledItemNetworkIndex();
+    }
+}
+
+void APGetPolledItemShouldNotify(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
+{
+    aFrame->code++;
+    if (aOut)
+    {
+        *aOut = CyberpunkArchipelago::APBridge::Get().GetPolledItemShouldNotify();
+    }
+}
+
 void APGetRestrictByMajorDistrict(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, int64_t)
 {
     aFrame->code++;
@@ -256,6 +274,8 @@ void PostRegisterTypes()
     RegisterNative(rtti, "Archipelago.AP_IsDeathLinkPending", "AP_IsDeathLinkPending", &APIsDeathLinkPending);
     RegisterNative(rtti, "Archipelago.AP_ClearDeathLink", "AP_ClearDeathLink", &APClearDeathLink);
     RegisterNative(rtti, "Archipelago.AP_PollItemQueue", "AP_PollItemQueue", &APPollItemQueue);
+    RegisterNative(rtti, "Archipelago.AP_GetPolledItemNetworkIndex", "AP_GetPolledItemNetworkIndex", &APGetPolledItemNetworkIndex);
+    RegisterNative(rtti, "Archipelago.AP_GetPolledItemShouldNotify", "AP_GetPolledItemShouldNotify", &APGetPolledItemShouldNotify);
     RegisterNative(rtti, "Archipelago.AP_GetRestrictByMajorDistrict", "AP_GetRestrictByMajorDistrict", &APGetRestrictByMajorDistrict);
     RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictionType", "AP_GetWeaponRestrictionType", &APGetWeaponRestrictionType);
     RegisterNative(rtti, "Archipelago.AP_GetWeaponRestrictPistol", "AP_GetWeaponRestrictPistol", &APGetWeaponRestrictPistol);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two related sync bugs reported by users on `main`:

1. **District access tokens received but district stays locked.** `APDistrictManager.UnlockDistrict` logged `District unlocked: ...` unconditionally, even when the underlying `SetQuestKey` call failed (e.g. quest system not ready yet). Users saw the "unlocked" log line but were still teleported out of the district.
2. **Traps re-apply on reconnect.** Every item popped from the native queue - including items the server was simply resending because the client reconnected - went through the live-grant path (`HandleItemReceived`), which always re-triggers traps. A user reported a trap they'd already received firing again after reconnecting mid-session.

A related contributing cause: items polled while no save was loaded (main menu / world not ready) were discarded from the native queue with nowhere to apply them, even though the server already considered them delivered - so a token received while reconnecting from the main menu could be lost until a full resync.

## Fix

- **Native → RedScript plumbing:** the item-receive callback now carries the item's position in the server's `ReceivedItems` stream (`networkIndex`) in addition to the existing notify flag, exposed via two new natives (`AP_GetPolledItemNetworkIndex`, `AP_GetPolledItemShouldNotify`).
- **Reconnect dedupe:** a new persistent quest fact (`ap_network_item_index`) tracks the highest network index applied via a live grant. `TCPClient.Pump()` now grants genuinely new items as before, but routes already-seen items (index below the persisted cursor) through `HandleItemSync` instead - which explicitly skips traps and reconciles durable state (quest keys, district tokens, weapon passes, inventory counts) without re-triggering one-shot effects.
- **No more discarding while unready:** `Pump()` no longer polls the native item queue at all when `APGameSystem` isn't available, so items stay queued until a save is loaded instead of being silently dropped.
- **District-token recovery:** `HandleItemSync`'s district-token branch now also retries `HandleDistrictUnlock`, recovering a token whose quest fact never got written the first time.
- **Honest unlock logging:** `UnlockDistrict` only logs "District unlocked" when the quest fact write actually succeeds, and logs an error otherwise, so the log can no longer claim a district is unlocked when it isn't.

## Scope

This is a targeted hotfix for `main` only. It intentionally does **not** touch `feature/v07`, which already has its own (larger) version of this reconnect fix.

## Testing

- Syntax-checked the modified C++ (`Archipelago.cpp`, `APBridge.cpp`) with `g++ -fsyntax-only` against the vendored dependencies; both compile cleanly. `RedscriptAPI.cpp` requires the Windows-only RED4ext SDK headers and could not be compiled in this environment, but the change there is a small mechanical addition following the exact pattern of the existing native wrappers.
- No RedScript compiler is available in this environment; changes were reviewed carefully against existing patterns in the file (scoping, service/system lookups, quest fact usage).
- Manual in-game verification (Windows + CET) is still recommended before release.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02c327f3-7839-4bbd-a112-56f9bc0a20d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02c327f3-7839-4bbd-a112-56f9bc0a20d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

