### PR TITLE
Fix district Access Token softlock (root cause: APGameState never loaded)

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictEnforcer.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictEnforcer.reds
@@ -63,8 +63,11 @@ public class APDistrictEnforcer extends ScriptableSystem {
         }
 
         for point in this.safePoints {
+            let candidateDistrictId: String = this.ParseEnumToDistrictID(point.District);
+            let candidateUnlocked: Bool = gameSystem.GetDistrictUnlockStatus(candidateDistrictId);
+            APLogger.LogDebug(s"GetNearestSafePoint: candidate district='\(candidateDistrictId)' unlocked=\(candidateUnlocked)");
             // Only consider unlocked districts
-            if gameSystem.GetDistrictUnlockStatus(this.ParseEnumToDistrictID(point.District)) {
+            if candidateUnlocked {
                 let distance: Float = Vector4.Distance(currentLocation, point.Position);
 
                 // If this is the first valid point, or closer than current best
@@ -73,6 +76,12 @@ public class APDistrictEnforcer extends ScriptableSystem {
                     bestDistance = distance;
                 }
             }
+        }
+
+        if bestDistance < 0.0 {
+            APLogger.LogWarning("GetNearestSafePoint: no unlocked safe points found - falling back to default Watson position");
+        } else {
+            APLogger.LogDebug(s"GetNearestSafePoint: chosen position=(\(decidedPosition.X), \(decidedPosition.Y), \(decidedPosition.Z)) distance=\(bestDistance)");
         }
 
         return decidedPosition;

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
@@ -19,6 +19,7 @@ public class APDistrictManager extends ScriptableSystem {
     // Check if a district is unlocked 
     public func IsDistrictUnlocked(districtId: String) -> Bool {
         let APGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        APLogger.LogDebug(s"IsDistrictUnlocked('\(districtId)'): APGameStateDefined=\(IsDefined(APGameState)), restrictByMajorDistrict=\(IsDefined(APGameState) && APGameState.restrictByMajorDistrict)");
         if !IsDefined(APGameState) || !APGameState.restrictByMajorDistrict {
             APLogger.LogDebug("District Restriction Disabled: All districts are considered unlocked");
             return true;
@@ -29,13 +30,17 @@ public class APDistrictManager extends ScriptableSystem {
             return false;
         }
         if StrCmp(districtId, "unknown") == 0 {
+            APLogger.LogDebug(s"IsDistrictUnlocked('\(districtId)'): 'unknown' district - treating as unlocked");
             return true;
         }
-        return this.questHandler.HasQuestKey(districtId);
+        let hasKey: Bool = this.questHandler.HasQuestKey(districtId);
+        APLogger.LogDebug(s"IsDistrictUnlocked('\(districtId)'): HasQuestKey=\(hasKey)");
+        return hasKey;
     }
 
     // Unlock a district
     public func UnlockDistrict(districtId: String) -> Void {
+        APLogger.LogDebug(s"UnlockDistrict('\(districtId)') called - questHandlerDefined=\(IsDefined(this.questHandler))");
         if !IsDefined(this.questHandler) {
             APLogger.LogDebug("APDistrictManager: Quest handler not initialized");
             return;
@@ -53,6 +58,7 @@ public class APDistrictManager extends ScriptableSystem {
 
     // Handle district restriction (called when player enters locked district)
     public func HandleDistrictRestriction(districtString: String) -> Void {
+        APLogger.LogDebug(s"HandleDistrictRestriction: rawDistrictString='\(districtString)' districtEnforcerDefined=\(IsDefined(this.districtEnforcer)) questHandlerDefined=\(IsDefined(this.questHandler))");
         if !IsDefined(this.districtEnforcer) {
             APLogger.LogDebug("APDistrictManager: District enforcer not initialized");
             return;
@@ -64,16 +70,21 @@ public class APDistrictManager extends ScriptableSystem {
         }
 
         // Don't enforce during lifepath intro
-        if !this.questHandler.IsPassedPrologue() {
+        let passedPrologue: Bool = this.questHandler.IsPassedPrologue();
+        APLogger.LogDebug(s"HandleDistrictRestriction: IsPassedPrologue=\(passedPrologue)");
+        if !passedPrologue {
             return;
         }
 
         // Get the major district enum from the game's district string
         let district: APDistrict = this.districtEnforcer.GetMajorDistrict(districtString);
         let districtId: String = this.districtEnforcer.ParseEnumToDistrictID(district);
+        APLogger.LogDebug(s"HandleDistrictRestriction: rawDistrictString='\(districtString)' -> APDistrict=\(district) -> districtId='\(districtId)'");
 
         // If district is unlocked, no need to teleport
-        if this.IsDistrictUnlocked(districtId) {
+        let unlocked: Bool = this.IsDistrictUnlocked(districtId);
+        APLogger.LogDebug(s"HandleDistrictRestriction: IsDistrictUnlocked('\(districtId)')=\(unlocked)");
+        if unlocked {
             return;
         }
 
@@ -93,7 +104,9 @@ public class APDistrictManager extends ScriptableSystem {
         }
 
         let currentPos: Vector4 = player.GetWorldPosition();
+        APLogger.LogDebug(s"TeleportToSafeZone: currentPos=(\(currentPos.X), \(currentPos.Y), \(currentPos.Z))");
         let nearestSafePoint: Vector4 = this.districtEnforcer.GetNearestSafePoint(currentPos);
+        APLogger.LogDebug(s"TeleportToSafeZone: nearestSafePoint=(\(nearestSafePoint.X), \(nearestSafePoint.Y), \(nearestSafePoint.Z))");
 
         // Set default rotation
         let targetRotation: EulerAngles = EulerAngles();

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
@@ -76,6 +76,18 @@ public class APDistrictManager extends ScriptableSystem {
             return;
         }
 
+        // Don't teleport while a post-spawn/connect item resync is still draining - the quest facts
+        // HasQuestKey reads below may not yet reflect district tokens the player already owns (see
+        // APGameState.itemResyncPending / TCPClient.ArmItemResyncPending). This is what caused the
+        // softlock: SyncData ran with an empty/incomplete item list right after a save reload, and
+        // entering a district before the AP item backlog finished replaying got the player kicked
+        // out of a district they actually owned the token for.
+        let APGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        if IsDefined(APGameState) && APGameState.IsItemResyncPending() {
+            APLogger.LogInfo("APDistrictManager: Deferring district enforcement - item resync still in progress");
+            return;
+        }
+
         // Get the major district enum from the game's district string
         let district: APDistrict = this.districtEnforcer.GetMajorDistrict(districtString);
         let districtId: String = this.districtEnforcer.ParseEnumToDistrictID(district);

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
@@ -31,8 +31,21 @@ public class APGameState extends ScriptableService {
     // This matches Python's len(received_items) counting for SYNC_COMPLETE
     public let totalNetworkItemsReceived: Int32;
 
-    private func OnAttach() -> Void {
-        this.items = new APItemList();
+    // True while a post-spawn/connect item resync is in flight (TCPClient is still draining the
+    // native item queue after a save load or fresh connect). District enforcement should not
+    // teleport the player while this is set, since the quest facts it reads may not reflect
+    // already-owned tokens yet - see APDistrictManager.HandleDistrictRestriction.
+    public let itemResyncPending: Bool;
+
+    // ScriptableService's lifecycle callback is OnLoad (runs once when the game starts, independent
+    // of save load/unload) - NOT OnAttach, which is a ScriptableSystem callback for save-bound
+    // singletons. Using OnAttach here meant this never ran, so `items` stayed undefined and every
+    // SyncData() call after a save reload silently aborted with "item list not available",
+    // preventing already-owned district tokens from being re-applied and causing softlocks.
+    private func OnLoad() -> Void {
+        if !IsDefined(this.items) {
+            this.items = new APItemList();
+        }
         APLogger.LogInfo("Cyberpunk 2077 Archipelago Game State Ready");
     }
 
@@ -47,8 +60,22 @@ public class APGameState extends ScriptableService {
 
     // ===== SIMPLE GETTERS/SETTERS ONLY =====
 
+    // Lazy-initializes `items` as a defensive fallback in case this is ever called before OnLoad
+    // has run, so callers never have to null-check the result.
     public func GetItems() -> ref<APItemList> {
+        if !IsDefined(this.items) {
+            APLogger.LogDebug("APGameState: Lazy-creating item list");
+            this.items = new APItemList();
+        }
         return this.items;
+    }
+
+    public func IsItemResyncPending() -> Bool {
+        return this.itemResyncPending;
+    }
+
+    public func SetItemResyncPending(value: Bool) -> Void {
+        this.itemResyncPending = value;
     }
 
     public func DiedFromDeathLink() -> Void {

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
@@ -55,8 +55,10 @@ public class APGameState extends ScriptableService {
         this.diedFromDeathLink = true;
     }
 
-    public func SetRestrictByMajorDistrict(value: Bool) -> Void {
+    public func SetRestrictByMajorDistrict(value: Bool) -> Bool {
+        let changed: Bool = (this.restrictByMajorDistrict && !value) || (!this.restrictByMajorDistrict && value);
         this.restrictByMajorDistrict = value;
+        return changed;
     }
 
     public func SetWeaponRestrictionConfig(

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -72,16 +72,21 @@ public class APGameSystem extends ScriptableSystem {
             return;
         }
 
-        APLogger.LogInfo("Starting Item Sync");
+        APLogger.LogInfo(s"Starting Item Sync - \(ArraySize(gameStateItems.Items)) tracked item(s), restrictByMajorDistrict=\(APGameState.restrictByMajorDistrict)");
 
         for item in gameStateItems.Items { 
             // Try to get the item from the FactsDB
             let itemCountFromFact: Int32 = this.inventoryHandler.GetItemFactCount(item.itemID);
             let stateCount: Int32 = item.totalFromAP;
 
+            if APItemParser.IsDistrictToken(item.itemID) {
+                APLogger.LogDebug(s"SyncData: district token '\(item.itemID)' - factCount=\(itemCountFromFact), totalFromAP=\(stateCount)");
+            }
+
             // If state has more than local, give the difference to player
             if itemCountFromFact < stateCount {
                 let difference: Int32 = stateCount - itemCountFromFact;
+                APLogger.LogDebug(s"SyncData: '\(item.itemID)' factCount(\(itemCountFromFact)) < totalFromAP(\(stateCount)) - applying difference=\(difference)");
 
                 // Route to appropriate handler based on item type
                 if StrCmp(item.itemID, APConstants.GetMoneyItemId()) == 0 {
@@ -103,6 +108,7 @@ public class APGameSystem extends ScriptableSystem {
                 }
                 else if APItemParser.IsDistrictToken(item.itemID) {
                     // District unlock tokens (binary - just unlock)
+                    APLogger.LogDebug(s"SyncData: retrying HandleDistrictUnlock('\(item.itemID)')");
                     this.HandleDistrictUnlock(item.itemID);
                 }
                 else if APItemParser.IsWeaponAuthorization(item.itemID) {
@@ -123,6 +129,7 @@ public class APGameSystem extends ScriptableSystem {
     }
 
     public func HandleDistrictRestriction(district: String) -> Void {
+        APLogger.LogDebug(s"APGameSystem: HandleDistrictRestriction('\(district)') - districtManager defined=\(IsDefined(this.districtManager))");
         if IsDefined(this.districtManager) {
             this.districtManager.HandleDistrictRestriction(district);
         } else {
@@ -131,6 +138,7 @@ public class APGameSystem extends ScriptableSystem {
     }
 
     public func HandleDistrictUnlock(district: String) -> Void {
+        APLogger.LogDebug(s"APGameSystem: HandleDistrictUnlock('\(district)') - districtManager defined=\(IsDefined(this.districtManager))");
         if IsDefined(this.districtManager) {
             this.districtManager.UnlockDistrict(district);
         } else {
@@ -145,8 +153,11 @@ public class APGameSystem extends ScriptableSystem {
 
     public func GetDistrictUnlockStatus(district: String) -> Bool {
         if IsDefined(this.districtManager) {
-            return this.districtManager.IsDistrictUnlocked(district);
+            let unlocked: Bool = this.districtManager.IsDistrictUnlocked(district);
+            APLogger.LogDebug(s"APGameSystem: GetDistrictUnlockStatus('\(district)')=\(unlocked)");
+            return unlocked;
         }
+        APLogger.LogDebug(s"APGameSystem: GetDistrictUnlockStatus('\(district)') - districtManager not available, returning false");
         return false;
     }
 
@@ -252,11 +263,14 @@ public class APGameSystem extends ScriptableSystem {
     // necessary - to reconcile here, since it recovers grants that never made it into a quest fact
     // the first time (e.g. the item arrived before the world/quest system was ready).
     public func HandleItemSync(item: String, gameState: ref<APGameState>) -> Void {
+        APLogger.LogDebug(s"HandleItemSync: item='\(item)' gameStateDefined=\(IsDefined(gameState))");
         if !IsDefined(gameState) || !IsDefined(gameState.items) {
+            APLogger.LogDebug("HandleItemSync: aborting - gameState or gameState.items not defined");
             return;
         }
 
         if !APItemParser.IsValidAPItem(item) {
+            APLogger.LogDebug(s"HandleItemSync: aborting - '\(item)' is not a valid AP item");
             return;
         }
 
@@ -288,6 +302,7 @@ public class APGameSystem extends ScriptableSystem {
         else if APItemParser.IsDistrictToken(item) {
             // Track district tokens so they can be re-synced on save load, and retry the unlock in
             // case the quest fact never got written the first time this item was received.
+            APLogger.LogDebug(s"HandleItemSync: district token '\(item)' - AddItem + retry HandleDistrictUnlock");
             gameState.items.AddItem(item, 1);
             this.HandleDistrictUnlock(item);
         }
@@ -300,8 +315,10 @@ public class APGameSystem extends ScriptableSystem {
 
     public func HandleItemReceived(item: String) -> Void {
         let APGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        APLogger.LogDebug(s"HandleItemReceived: item='\(item)' gameStateDefined=\(IsDefined(APGameState))");
 
         if !APItemParser.IsValidAPItem(item) {
+            APLogger.LogDebug(s"HandleItemReceived: aborting - '\(item)' is not a valid AP item");
             return;
         }
 
@@ -347,6 +364,7 @@ public class APGameSystem extends ScriptableSystem {
             this.HandleProgressiveItem(item);
         }
         else if APItemParser.IsDistrictToken(item) {
+            APLogger.LogDebug(s"HandleItemReceived: district token '\(item)' - AddItem + HandleDistrictUnlock (live grant)");
             if IsDefined(APGameState.items) {
                 APGameState.items.AddItem(item, 1);
             }
@@ -389,10 +407,10 @@ public class APGameSystem extends ScriptableSystem {
 public final func Update(evt: ref<DistrictEnteredEvent>) -> Void {
     let districtString: String = TDBID.ToStringDEBUG(evt.district);
     let APGameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+    APLogger.LogDebug(s"DistrictEnteredEvent fired: rawDistrict='\(districtString)' APGameSystemDefined=\(IsDefined(APGameSystem))");
     if IsDefined(APGameSystem) {
         APGameSystem.HandleDistrictRestriction(districtString);
     }
-    //APLogger.LogInfo(districtString);
 }
 
 // Making sure that the player is respawned before allowing another Deathlink call.
@@ -401,9 +419,9 @@ protected cb func OnMakePlayerVisibleAfterSpawn(evt: ref<EndGracePeriodAfterSpaw
     let result = wrappedMethod(evt);
     let APGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
     let APGameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
-    //APLogger.LogInfo( s"Character Visible");
+    APLogger.LogDebug(s"OnMakePlayerVisibleAfterSpawn: EndGracePeriodAfterSpawn fired - APGameStateDefined=\(IsDefined(APGameState)), APGameSystemDefined=\(IsDefined(APGameSystem))");
     if IsDefined(APGameState) {
-        //APLogger.LogInfo( "AP Game State Defined");
+        APLogger.LogDebug("OnSpawn: Running SyncData + SendSyncChecks");
         APGameState.HandlePlayerRespawn();
         APGameSystem.SyncData();
         APGameSystem.SendSyncChecks();

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -175,7 +175,9 @@ public class APGameSystem extends ScriptableSystem {
         let progressionLevel: Int32 = this.inventoryHandler.GetItemFactCount(item) + 1;
         let resolvedItem: String = APItemProgression.GetProgressiveItem(item, progressionLevel);
         this.AddInventoryItem(resolvedItem);
-        APGameState.items.AddItem(resolvedItem, 1);
+        if IsDefined(APGameState) {
+            APGameState.GetItems().AddItem(resolvedItem, 1);
+        }
         this.inventoryHandler.IncrementItemFact(item, 1);
     }
 
@@ -264,8 +266,8 @@ public class APGameSystem extends ScriptableSystem {
     // the first time (e.g. the item arrived before the world/quest system was ready).
     public func HandleItemSync(item: String, gameState: ref<APGameState>) -> Void {
         APLogger.LogDebug(s"HandleItemSync: item='\(item)' gameStateDefined=\(IsDefined(gameState))");
-        if !IsDefined(gameState) || !IsDefined(gameState.items) {
-            APLogger.LogDebug("HandleItemSync: aborting - gameState or gameState.items not defined");
+        if !IsDefined(gameState) {
+            APLogger.LogDebug("HandleItemSync: aborting - gameState not defined");
             return;
         }
 
@@ -274,13 +276,16 @@ public class APGameSystem extends ScriptableSystem {
             return;
         }
 
+        // GetItems() lazily creates the list if needed, so this is never null.
+        let items: ref<APItemList> = gameState.GetItems();
+
         // Increment NetworkItem counter for each item processed (matches Python's len(received_items))
         gameState.totalNetworkItemsReceived += 1;
 
         // Always add to persistent storage first so items can be re-synced on save load
         if APItemParser.IsQuestKey(item) {
             // Quest keys are tracked even though they're binary (0 or 1)
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
             this.AddQuestKey(item);
         }
         else if APItemParser.IsTrap(item) {
@@ -289,25 +294,25 @@ public class APGameSystem extends ScriptableSystem {
         }
         else if APItemParser.IsEddies(item) {
             let amount: Int32 = APItemParser.ParseEddiesAmount(item);
-            gameState.items.AddItem(APConstants.GetMoneyItemId(), amount);
+            items.AddItem(APConstants.GetMoneyItemId(), amount);
         }
         else if APItemParser.IsInventoryItem(item) {
             let itemId: String = APItemParser.ParseInventoryItemId(item);
-            gameState.items.AddItem(itemId, 1);
+            items.AddItem(itemId, 1);
         }
         else if APItemParser.IsProgressiveItem(item) {
             // Track progressive items so they can be re-synced on save load
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
         }
         else if APItemParser.IsDistrictToken(item) {
             // Track district tokens so they can be re-synced on save load, and retry the unlock in
             // case the quest fact never got written the first time this item was received.
             APLogger.LogDebug(s"HandleItemSync: district token '\(item)' - AddItem + retry HandleDistrictUnlock");
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
             this.HandleDistrictUnlock(item);
         }
         else if APItemParser.IsWeaponAuthorization(item) {
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
             this.HandleWeaponUnlock(item);
         }
         // Note: Skill points not added as they're not fully implemented
@@ -322,14 +327,17 @@ public class APGameSystem extends ScriptableSystem {
             return;
         }
 
-        // Increment NetworkItem counter for real-time items from queue worker
+        // GetItems() lazily creates the list if needed, so items is never null once gameState is defined.
+        let items: ref<APItemList>;
         if IsDefined(APGameState) {
+            items = APGameState.GetItems();
+            // Increment NetworkItem counter for real-time items from queue worker
             APGameState.totalNetworkItemsReceived += 1;
         }
 
         if APItemParser.IsQuestKey(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.AddQuestKey(item);
         }
@@ -345,34 +353,34 @@ public class APGameSystem extends ScriptableSystem {
         }
         else if APItemParser.IsEddies(item) {
             let amount: Int32 = APItemParser.ParseEddiesAmount(item);
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(APConstants.GetMoneyItemId(), amount);
+            if IsDefined(items) {
+                items.AddItem(APConstants.GetMoneyItemId(), amount);
             }
             this.AddEddies(amount);
         }
         else if APItemParser.IsInventoryItem(item) {
             let itemId: String = APItemParser.ParseInventoryItemId(item);
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(itemId, 1);
+            if IsDefined(items) {
+                items.AddItem(itemId, 1);
             }
             this.AddInventoryItem(itemId);
         }
         else if APItemParser.IsProgressiveItem(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.HandleProgressiveItem(item);
         }
         else if APItemParser.IsDistrictToken(item) {
             APLogger.LogDebug(s"HandleItemReceived: district token '\(item)' - AddItem + HandleDistrictUnlock (live grant)");
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.HandleDistrictUnlock(item);
         }
         else if APItemParser.IsWeaponAuthorization(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.HandleWeaponUnlock(item);
         }
@@ -423,6 +431,16 @@ protected cb func OnMakePlayerVisibleAfterSpawn(evt: ref<EndGracePeriodAfterSpaw
     if IsDefined(APGameState) {
         APLogger.LogDebug("OnSpawn: Running SyncData + SendSyncChecks");
         APGameState.HandlePlayerRespawn();
+
+        // Defer district enforcement until the post-spawn item backlog (if connected) has been
+        // fully drained by TCPClient.Pump - see APGameState.itemResyncPending. Must happen before
+        // SyncData/SendSyncChecks so any DistrictEnteredEvent firing immediately after spawn is
+        // already covered.
+        let tcpClient: ref<TCPClient> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.TCPClient") as TCPClient;
+        if IsDefined(tcpClient) {
+            tcpClient.OnPlayerSpawned();
+        }
+
         APGameSystem.SyncData();
         APGameSystem.SendSyncChecks();
 

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -54,7 +54,24 @@ public class APGameSystem extends ScriptableSystem {
 
     public func SyncData() -> Void {
         let APGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        if !IsDefined(APGameState) {
+            APLogger.LogDebug("APGameSystem: Cannot sync data - game state not available");
+            return;
+        }
+
         let gameStateItems: ref<APItemList> = APGameState.GetItems();
+        if !IsDefined(gameStateItems) {
+            APLogger.LogDebug("APGameSystem: Cannot sync data - item list not available");
+            return;
+        }
+
+        // Handlers are cached in OnAttach; ScriptableSystems (and this cache) are recreated on every
+        // save load, so guard against SyncData running before OnAttach has resolved them.
+        if !IsDefined(this.inventoryHandler) || !IsDefined(this.questHandler) {
+            APLogger.LogDebug("APGameSystem: Cannot sync data - inventory/quest handler not available");
+            return;
+        }
+
         APLogger.LogInfo("Starting Item Sync");
 
         for item in gameStateItems.Items { 

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestHandler.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APQuestHandler.reds
@@ -19,6 +19,7 @@ public class APQuestHandler extends ScriptableSystem {
         }
 
         questSystem.SetFact(StringToName(questKeyId), 1);
+        APLogger.LogDebug(s"APQuestHandler: SetQuestKey('\(questKeyId)') -> fact now reads \(questSystem.GetFact(StringToName(questKeyId)))");
         return true;
     }
 
@@ -27,8 +28,11 @@ public class APQuestHandler extends ScriptableSystem {
         let questSystem: ref<QuestsSystem> = GameInstance.GetQuestsSystem(this.GetGameInstance());
 
         if IsDefined(questSystem) {
-            return questSystem.GetFact(StringToName(questKeyId)) >= 1;
+            let factValue: Int32 = questSystem.GetFact(StringToName(questKeyId));
+            APLogger.LogDebug(s"APQuestHandler: HasQuestKey('\(questKeyId)') - raw fact value=\(factValue)");
+            return factValue >= 1;
         }
+        APLogger.LogDebug(s"APQuestHandler: HasQuestKey('\(questKeyId)') - quest system not available, returning false");
         return false;
     }
 
@@ -70,10 +74,15 @@ public class APQuestHandler extends ScriptableSystem {
 
     // Check if heist intro is complete (used for district enforcement)
     public func IsPassedPrologue() -> Bool {
-        return this.GetQuestFact(APConstants.GetQuestQ000Done()) > 0 && 
-        this.GetQuestFact(APConstants.GetQuestQ001Done()) > 0 && 
-        this.GetQuestFact(APConstants.GetQuestQ101_01_firestormDone()) > 0 &&
-        this.GetQuestFact(APConstants.GetVPillsFact()) > 0;
+        let q000Done: Int32 = this.GetQuestFact(APConstants.GetQuestQ000Done());
+        let q001Done: Int32 = this.GetQuestFact(APConstants.GetQuestQ001Done());
+        let firestormDone: Int32 = this.GetQuestFact(APConstants.GetQuestQ101_01_firestormDone());
+        let vPills: Int32 = this.GetQuestFact(APConstants.GetVPillsFact());
+        let result: Bool = q000Done > 0 && q001Done > 0 && firestormDone > 0 && vPills > 0;
+        APLogger.LogDebug(
+            s"APQuestHandler: IsPassedPrologue - q000Done=\(q000Done), q001Done=\(q001Done), firestormDone=\(firestormDone), vPills=\(vPills) -> \(result)"
+        );
+        return result;
     }
 
     // Send a location check to the server

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
@@ -2,8 +2,10 @@ module Archipelago
 
 public class APWeaponRestrictionEnforcer extends ScriptableService {
 
-    private func OnAttach() -> Void {
-        APLogger.LogInfo("APWeaponRestrictionEnforcer attached and ready");
+    // ScriptableService's lifecycle callback is OnLoad, not OnAttach (that's for ScriptableSystem) -
+    // see APGameState.OnLoad for details on why this matters.
+    private func OnLoad() -> Void {
+        APLogger.LogInfo("APWeaponRestrictionEnforcer loaded and ready");
     }
 
     // This function is called by the game's equipment system when checking if a weapon can be equipped

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -12,6 +12,12 @@ public class TCPClient extends ScriptableService {
     private let lastGameSystemAvailableLogged: Bool = false;
     private let hasLoggedGameSystemAvailability: Bool = false;
 
+    // Settle-tracking for APGameState.itemResyncPending (see ArmItemResyncPending). Counts Pump
+    // ticks since pending was armed, and consecutive ticks with no item queue activity, so we know
+    // when the post-spawn/connect backlog has finished draining and district enforcement can resume.
+    private let ticksSincePendingSet: Int32 = 0;
+    private let emptyPollStreakWhilePending: Int32 = 0;
+
     public func Configure(server: String, game: String, slot: String, pass: String) -> Void {
         this.serverAddress = server;
         this.gameName = game;
@@ -138,12 +144,41 @@ public class TCPClient extends ScriptableService {
     public func SendSyncCompleteResponse(currentCount: Int32) -> Void {
     }
 
+    // Marks a district-enforcement deferral window: APDistrictManager.HandleDistrictRestriction will
+    // not teleport the player while APGameState.itemResyncPending is set, since quest facts read
+    // during this window may not yet reflect tokens the player already owns (the native item queue
+    // is still being drained by Pump after a save load or fresh connect). Resets the settle counters
+    // so Pump starts watching for the queue to go quiet again.
+    private func ArmItemResyncPending() -> Void {
+        let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        if !IsDefined(gameState) {
+            return;
+        }
+        if !gameState.IsItemResyncPending() {
+            APLogger.LogDebug("TCPClient: Arming item resync pending - deferring district enforcement until item queue settles");
+        }
+        gameState.SetItemResyncPending(true);
+        this.ticksSincePendingSet = 0;
+        this.emptyPollStreakWhilePending = 0;
+    }
+
+    // Called once per spawn (from APGameSystem's OnMakePlayerVisibleAfterSpawn hook) so enforcement
+    // is deferred as soon as possible after a save load, before any DistrictEnteredEvent can fire.
+    public func OnPlayerSpawned() -> Void {
+        if this.IsConnected() {
+            this.ArmItemResyncPending();
+        }
+    }
+
     public func Pump() -> Void {
+        // Fetched once up front and reused for both the slot-config mirroring below and the
+        // item-resync-pending settle tracking at the end of this function.
+        let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+
         // Apply slot config received from the server (e.g. district restriction).
         // The native bridge captures restrict_by_major_district from the Connected
         // packet's slot_data; mirror it into APGameState so enforcement can read it.
         if this.IsConnected() {
-            let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
             if IsDefined(gameState) {
                 let districtRestrictionChanged: Bool = gameState.SetRestrictByMajorDistrict(AP_GetRestrictByMajorDistrict());
                 if districtRestrictionChanged {
@@ -183,15 +218,23 @@ public class TCPClient extends ScriptableService {
             APLogger.LogDebug(s"TCPClient.Pump: APGameSystem availability changed -> \(gameSystemAvailable)");
             if !gameSystemAvailable {
                 APLogger.LogDebug("TCPClient.Pump: item queue will not be polled/drained until a save is loaded");
+            } else if this.IsConnected() {
+                // The system can become available without a fresh spawn callback (e.g. it attaches
+                // right as Pump runs). Defer enforcement here too, same as OnPlayerSpawned.
+                APLogger.LogDebug("TCPClient.Pump: APGameSystem became available while connected - deferring district enforcement until item queue settles");
+                this.ArmItemResyncPending();
             }
             this.lastGameSystemAvailableLogged = gameSystemAvailable;
             this.hasLoggedGameSystemAvailability = true;
         }
+
+        let itemAppliedThisTick: Bool = false;
         if IsDefined(gameSystem) {
             let nextItemId: Int64 = AP_PollItemQueue();
             if nextItemId >= 0l {
                 let itemId: String = APNativeMappings.ResolveItemId(nextItemId);
                 if StrLen(itemId) > 0 {
+                    itemAppliedThisTick = true;
                     let networkIndex: Int32 = AP_GetPolledItemNetworkIndex();
                     let inventoryHandler: ref<APInventoryHandler> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APInventoryHandler") as APInventoryHandler;
                     let shouldGrant: Bool = true;
@@ -213,7 +256,6 @@ public class TCPClient extends ScriptableService {
                         if networkIndex < lastProcessedIndex {
                             shouldGrant = false;
                             APLogger.LogDebug(s"TCPClient.Pump: '\(itemId)' networkIndex(\(networkIndex)) < lastProcessedIndex(\(lastProcessedIndex)) - routing through HandleItemSync (resync)");
-                            let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
                             if IsDefined(gameState) {
                                 gameSystem.HandleItemSync(itemId, gameState);
                             }
@@ -229,6 +271,33 @@ public class TCPClient extends ScriptableService {
                     }
                 } else {
                     APLogger.LogDebug(s"TCPClient: No item mapping for AP item ID \(ToString(nextItemId))");
+                }
+            }
+        }
+
+        // Settle tracking for APGameState.itemResyncPending (see ArmItemResyncPending). Once the
+        // item queue has gone quiet for a bit (or a hard timeout elapses as a safety net), re-run
+        // SyncData once more to catch anything the backlog just delivered, then let district
+        // enforcement resume.
+        if IsDefined(gameState) && gameState.IsItemResyncPending() {
+            this.ticksSincePendingSet += 1;
+            if itemAppliedThisTick {
+                this.emptyPollStreakWhilePending = 0;
+            } else {
+                this.emptyPollStreakWhilePending += 1;
+            }
+
+            let emptyPollSettleThreshold: Int32 = 40; // ~2s of no new items at ~20 Pump ticks/sec
+            let pendingHardTimeoutTicks: Int32 = 600; // ~30s safety net so enforcement can't stay off forever
+            if this.emptyPollStreakWhilePending >= emptyPollSettleThreshold || this.ticksSincePendingSet >= pendingHardTimeoutTicks {
+                APLogger.LogInfo(
+                    s"TCPClient.Pump: item queue settled (emptyPollStreak=\(this.emptyPollStreakWhilePending), ticksSincePending=\(this.ticksSincePendingSet)) - resuming district enforcement"
+                );
+                gameState.SetItemResyncPending(false);
+                this.ticksSincePendingSet = 0;
+                this.emptyPollStreakWhilePending = 0;
+                if IsDefined(gameSystem) {
+                    gameSystem.SyncData();
                 }
             }
         }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -176,7 +176,10 @@ public class TCPClient extends ScriptableService {
         // queued here means it's applied as soon as a save is loaded and Pump runs again.
         let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
         let gameSystemAvailable: Bool = IsDefined(gameSystem);
-        if !this.hasLoggedGameSystemAvailability || gameSystemAvailable != this.lastGameSystemAvailableLogged {
+        // Bool has no != overload in RedScript - use the same XOR-style comparison as
+        // APGameState.SetRestrictByMajorDistrict / SetWeaponRestrictionConfig.
+        let gameSystemAvailabilityChanged: Bool = (gameSystemAvailable && !this.lastGameSystemAvailableLogged) || (!gameSystemAvailable && this.lastGameSystemAvailableLogged);
+        if !this.hasLoggedGameSystemAvailability || gameSystemAvailabilityChanged {
             APLogger.LogDebug(s"TCPClient.Pump: APGameSystem availability changed -> \(gameSystemAvailable)");
             if !gameSystemAvailable {
                 APLogger.LogDebug("TCPClient.Pump: item queue will not be polled/drained until a save is loaded");

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -7,6 +7,10 @@ public class TCPClient extends ScriptableService {
     private let password: String = "";
     private let initialized: Bool = false;
     private let lastConnectionError: String = "";
+    // Tracks APGameSystem availability across Pump ticks so we can log only on transitions
+    // (Pump runs ~20x/sec, so logging every tick would flood scripting.log).
+    private let lastGameSystemAvailableLogged: Bool = false;
+    private let hasLoggedGameSystemAvailability: Bool = false;
 
     public func Configure(server: String, game: String, slot: String, pass: String) -> Void {
         this.serverAddress = server;
@@ -141,7 +145,10 @@ public class TCPClient extends ScriptableService {
         if this.IsConnected() {
             let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
             if IsDefined(gameState) {
-                gameState.SetRestrictByMajorDistrict(AP_GetRestrictByMajorDistrict());
+                let districtRestrictionChanged: Bool = gameState.SetRestrictByMajorDistrict(AP_GetRestrictByMajorDistrict());
+                if districtRestrictionChanged {
+                    APLogger.LogInfo(s"District restriction config received: restrictByMajorDistrict=\(gameState.restrictByMajorDistrict)");
+                }
                 let weaponConfigChanged: Bool = gameState.SetWeaponRestrictionConfig(
                     AP_GetWeaponRestrictionType(),
                     AP_GetWeaponRestrictPistol(),
@@ -168,6 +175,15 @@ public class TCPClient extends ScriptableService {
         // apply it, permanently losing it even though the server considers it delivered. Leaving it
         // queued here means it's applied as soon as a save is loaded and Pump runs again.
         let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+        let gameSystemAvailable: Bool = IsDefined(gameSystem);
+        if !this.hasLoggedGameSystemAvailability || gameSystemAvailable != this.lastGameSystemAvailableLogged {
+            APLogger.LogDebug(s"TCPClient.Pump: APGameSystem availability changed -> \(gameSystemAvailable)");
+            if !gameSystemAvailable {
+                APLogger.LogDebug("TCPClient.Pump: item queue will not be polled/drained until a save is loaded");
+            }
+            this.lastGameSystemAvailableLogged = gameSystemAvailable;
+            this.hasLoggedGameSystemAvailability = true;
+        }
         if IsDefined(gameSystem) {
             let nextItemId: Int64 = AP_PollItemQueue();
             if nextItemId >= 0l {
@@ -176,6 +192,13 @@ public class TCPClient extends ScriptableService {
                     let networkIndex: Int32 = AP_GetPolledItemNetworkIndex();
                     let inventoryHandler: ref<APInventoryHandler> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APInventoryHandler") as APInventoryHandler;
                     let shouldGrant: Bool = true;
+                    let lastProcessedIndexForLog: Int32 = -1;
+                    if IsDefined(inventoryHandler) {
+                        lastProcessedIndexForLog = inventoryHandler.GetLastNetworkItemIndex();
+                    }
+                    APLogger.LogDebug(
+                        s"TCPClient.Pump: polled AP item id=\(ToString(nextItemId)) resolvedItemId='\(itemId)' networkIndex=\(networkIndex) lastProcessedIndex=\(lastProcessedIndexForLog)"
+                    );
 
                     // If this item's network index is older than the last one we already applied
                     // live, the server is resending something we've already processed (typically on
@@ -186,6 +209,7 @@ public class TCPClient extends ScriptableService {
                         let lastProcessedIndex: Int32 = inventoryHandler.GetLastNetworkItemIndex();
                         if networkIndex < lastProcessedIndex {
                             shouldGrant = false;
+                            APLogger.LogDebug(s"TCPClient.Pump: '\(itemId)' networkIndex(\(networkIndex)) < lastProcessedIndex(\(lastProcessedIndex)) - routing through HandleItemSync (resync)");
                             let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
                             if IsDefined(gameState) {
                                 gameSystem.HandleItemSync(itemId, gameState);
@@ -194,6 +218,7 @@ public class TCPClient extends ScriptableService {
                     }
 
                     if shouldGrant {
+                        APLogger.LogDebug(s"TCPClient.Pump: '\(itemId)' routing through HandleItemReceived (live grant)");
                         gameSystem.HandleItemReceived(itemId);
                         if networkIndex >= 0 && IsDefined(inventoryHandler) {
                             inventoryHandler.SetLastNetworkItemIndex(networkIndex + 1);

--- a/worlds/cyberpunk2077/archipelago.json
+++ b/worlds/cyberpunk2077/archipelago.json
@@ -2,5 +2,5 @@
   "game": "Cyberpunk 2077",
   "authors": ["247Tossing"],
   "minimum_ap_version": "0.6.6",
-  "world_version": "0.6.1"
+  "world_version": "0.6.4"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (confirmed from a full `scripting.log` capture)

`APGameState` and `APWeaponRestrictionEnforcer` extend Codeware's `ScriptableService`, whose lifecycle callback is **`OnLoad`** (runs once at game start), not `OnAttach` (that's a `ScriptableSystem` callback for save-bound singletons). Both classes used `OnAttach`, so it **never ran** - `APGameState.items` stayed undefined for the entire session, and every `SyncData()` call after a save reload silently aborted with `Cannot sync data - item list not available`.

This is the actual softlock mechanism:

1. Player owns a district Access Token; the live `HandleItemReceived` grant sets the quest fact correctly, so the district reads as unlocked for the rest of that session.
2. Player saves/reloads. `ScriptableSystem`s (including `APGameSystem`, `APDistrictManager`) are recreated; quest facts are rebuilt from the save's factlist.
3. Spawn calls `SyncData()` to re-apply any AP-owned items to quest facts - but it aborts immediately (item list not available), so nothing gets re-applied.
4. If the player enters a restricted district before the AP server happens to resend that item live (which can take minutes), `HasQuestKey` reads `0` and `APDistrictManager` teleports them out - even though they own the token. This matches the field reports (Pacifica Chapel fast travel, Nocturne/Hanako's AV in City Center) and the log evidence: `HasQuestKey('ap_dat_pacificaAccessToken') - raw fact value=0` → `District locked. Requires Access Token`, followed ~7 minutes later by the AP stream re-granting all district tokens live and recovery.

## Fix

1. **`APGameState.OnAttach` → `OnLoad`** (same fix applied to `APWeaponRestrictionEnforcer`), so `items` actually initializes. `GetItems()` also lazily creates the list as a defensive fallback.
2. **Route all item tracking through `GetItems()`** in `HandleItemReceived` / `HandleItemSync` / `HandleProgressiveItem` instead of touching the raw `items` field with silent no-ops when undefined, so district tokens (and everything else) are reliably recorded for `SyncData` to reconcile later.
3. **Defer district enforcement while an item resync is in flight.** Even with (1)+(2), a fresh game boot still has an empty tracked-item list until `TCPClient.Pump` finishes draining the native `ReceivedItems` queue. Added `APGameState.itemResyncPending`, armed on spawn (and defensively when `APGameSystem` first becomes available while connected), and cleared once the item queue has been quiet for ~2s or after a 30s hard-timeout safety net - at which point `SyncData` runs once more. `APDistrictManager.HandleDistrictRestriction` skips the teleport entirely while this is set.

## Testing

RedScript-only change; no Linux-runnable compiler/bundle in this environment (needs the game's `final.redscripts`, which CI doesn't build either - it only builds the native plugin and packages the mod zip). Verified via brace/paren balance checks per file and manual review against Codeware's documented `ScriptableService` API (`OnLoad`, not `OnAttach`).

### In-game test plan for the reporter
1. Connect to an AP slot that already owns all major district tokens.
2. Confirm the log shows `Cyberpunk 2077 Archipelago Game State Ready` and spawn logs `Starting Item Sync - N tracked item(s)` (not "item list not available").
3. Save, reload, and immediately enter Pacifica / City Center before any item backlog would normally finish - should not teleport.
4. Full game restart + reconnect - enforcement may briefly defer, then resumes; no softlock during the backlog.
5. With restrictions on and a district *not* owned, confirm teleport still happens once resync clears.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c808440-4355-4ff8-b560-731ebbd4b073?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c808440-4355-4ff8-b560-731ebbd4b073&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

