### PR TITLE
Bump world_version to 0.6.4

### DIFF
--- a/worlds/cyberpunk2077/archipelago.json
+++ b/worlds/cyberpunk2077/archipelago.json
@@ -2,5 +2,5 @@
   "game": "Cyberpunk 2077",
   "authors": ["247Tossing"],
   "minimum_ap_version": "0.6.6",
-  "world_version": "0.6.1"
+  "world_version": "0.6.4"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps `world_version` in [`worlds/cyberpunk2077/archipelago.json`](worlds/cyberpunk2077/archipelago.json) from `0.6.1` to `0.6.4`, per [`CONTRIBUTING.md`](CONTRIBUTING.md#building) this is the single source of truth for the mod/world version used by the release build tooling (apworld, mod zip, PopTracker pack) and tag-triggered CI (tag `v0.6.4` must match this value).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c808440-4355-4ff8-b560-731ebbd4b073?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c808440-4355-4ff8-b560-731ebbd4b073&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

