### PR TITLE
Gate Jackson Plains Ripperdoc stalls behind Aldecaldos camp move

### DIFF
--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APConstants.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APConstants.reds
@@ -168,6 +168,19 @@ public class APConstants {
     public static func GetNGPlusStandaloneQ101StartFact() -> String { return "ngplus_standalone_q101_start"; }
     public static func GetNetworkItemIndexFact() -> String { return "ap_network_item_index"; }
 
+    // ===== JACKSON PLAINS RIPPERDOC (ALDECALDOS CAMP MOVE) =====
+    // The Aldecaldos camp relocates within Jackson Plains once Panam's side-quest chain
+    // finishes at this capstone quest. Stall 1 is the pre-move camp ripperdoc and becomes
+    // permanently unreachable once the camp moves; see APGameSystem.ReleaseJacksonPlainsRipperdocStall1Checks.
+    public static func GetQueenOfTheHighwayQuestId() -> String { return "sq027_02_raffen_shiv_attack"; }
+    public static func GetJacksonPlainsRipperdocStall1LocationIds() -> array<String> {
+        let locationIds: array<String>;
+        ArrayPush(locationIds, "VendorCheck_BlsInaSe1Ripperdoc01_1");
+        ArrayPush(locationIds, "VendorCheck_BlsInaSe1Ripperdoc01_2");
+        ArrayPush(locationIds, "VendorCheck_BlsInaSe1Ripperdoc01_3");
+        return locationIds;
+    }
+
     // ===== SERVICE NAMES =====
     // CNames for retrieving services from the game engine
     public static func GetAPGameSystemName() -> CName { return n"Archipelago.APGameSystem"; }

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -220,12 +220,52 @@ public class APGameSystem extends ScriptableSystem {
             return true;
         }
 
+        // Aldecaldos camp relocates to Jackson Plains once "Queen of the Highway" completes,
+        // making Stall 1 (pre-move camp ripperdoc) permanently unreachable. Release any
+        // unchecked Stall 1 vendor checks so vendor-sanity runs never get stuck on them.
+        if StrCmp(questId, APConstants.GetQueenOfTheHighwayQuestId()) == 0 && Equals(state, gameJournalEntryState.Succeeded) {
+            APQuestLocationLookup.HandleSucceededQuest(questSystem, tcpService, questId);
+            APGameSystem.ReleaseJacksonPlainsRipperdocStall1Checks(this.GetGameInstance());
+            return true;
+        }
+
         if Equals(state, gameJournalEntryState.Succeeded) {
             APLogger.LogDebug(s"HandleJournalStateChange completion: questId=\(questId)");
             APQuestLocationLookup.HandleSucceededQuest(questSystem, tcpService, questId);
         }
 
         return true;
+    }
+
+    // Aldecaldos camp relocates to Jackson Plains once "Queen of the Highway" completes,
+    // making Stall 1 (pre-move camp ripperdoc) permanently unreachable. Idempotent and
+    // safe to call from both the quest-completion hook and on spawn (e.g. after loading a
+    // save where the quest was already finished before the player reconnected) — only
+    // sends checks that are part of this run's vendor sanity stock and haven't already
+    // been sent, and no-ops entirely until the camp has actually moved.
+    public static func ReleaseJacksonPlainsRipperdocStall1Checks(game: GameInstance) -> Void {
+        let questSystem: ref<QuestsSystem> = GameInstance.GetQuestsSystem(game) as QuestsSystem;
+        let tcpService: ref<TCPClient> = GameInstance.GetScriptableServiceContainer().GetService(APConstants.GetTCPClientName()) as TCPClient;
+        let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(APConstants.GetAPGameStateName()) as APGameState;
+        if !IsDefined(questSystem) || !IsDefined(tcpService) || !IsDefined(gameState) {
+            return;
+        }
+        if !gameState.vendorSanityEnabled {
+            return;
+        }
+
+        let campMovedFact: CName = StringToName(s"ap_\(APConstants.GetQueenOfTheHighwayQuestId())");
+        if questSystem.GetFact(campMovedFact) < 1 {
+            // Camp hasn't moved yet — Stall 1 is still reachable normally.
+            return;
+        }
+
+        let locationIds: array<String> = APConstants.GetJacksonPlainsRipperdocStall1LocationIds();
+        for locationId in locationIds {
+            if gameState.IsVendorCheckInRun(locationId) {
+                APQuestLocationLookup.SendLocationCheck(questSystem, tcpService, locationId);
+            }
+        }
     }
 
     //Progressive Items
@@ -487,6 +527,7 @@ protected cb func OnMakePlayerVisibleAfterSpawn(evt: ref<EndGracePeriodAfterSpaw
         APGameState.HandlePlayerRespawn();
         APGameSystem.SyncData();
         APNGPlusBridge.TryReleasePrologueChecksOnSpawn(GetGameInstance());
+        APGameSystem.ReleaseJacksonPlainsRipperdocStall1Checks(GetGameInstance());
         APGameSystem.SendSyncChecks();
 
         // Register the Archipelago phone contact on every spawn

--- a/worlds/cyberpunk2077/locations.py
+++ b/worlds/cyberpunk2077/locations.py
@@ -613,9 +613,19 @@ location_table: Dict[str, LocationData] = {
     "VendorCheck_WbrJpnRipperdoc02_1": LocationData(display_name="Japantown Ripperdoc (Clinic 02) 1", regions=("Westbrook",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
     "VendorCheck_WbrJpnRipperdoc02_2": LocationData(display_name="Japantown Ripperdoc (Clinic 02) 2", regions=("Westbrook",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
     "VendorCheck_WbrJpnRipperdoc02_3": LocationData(display_name="Japantown Ripperdoc (Clinic 02) 3", regions=("Westbrook",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.PRIORITY, vendor_subtype="ripperdoc"),
+    # Stall 1 is the pre-camp-move Aldecaldos ripperdoc: it becomes unreachable once the
+    # player finishes Panam's side-quest chain (capstone "Queen of the Highway") and the
+    # camp relocates. All three slots are EXCLUDED so generation never places progression
+    # here; the client auto-releases any unchecked slots when the camp moves (see
+    # APGameSystem.reds / APQuestLocationLookup.reds).
     "VendorCheck_BlsInaSe1Ripperdoc01_1": LocationData(display_name="Jackson Plains Ripperdoc (Stall 1) 1", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
     "VendorCheck_BlsInaSe1Ripperdoc01_2": LocationData(display_name="Jackson Plains Ripperdoc (Stall 1) 2", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
-    "VendorCheck_BlsInaSe1Ripperdoc01_3": LocationData(display_name="Jackson Plains Ripperdoc (Stall 1) 3", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.PRIORITY, vendor_subtype="ripperdoc"),
+    "VendorCheck_BlsInaSe1Ripperdoc01_3": LocationData(display_name="Jackson Plains Ripperdoc (Stall 1) 3", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
+    # Stall 2 is the post-camp-move Aldecaldos ripperdoc: it only exists once the camp has
+    # relocated, which requires Panam's side-quest chain. It is only populated when side
+    # quests are included in generation (see create_region()'s VENDOR filter in regions.py)
+    # and is gated behind "Queen of the Highway" in addition to the usual ripperdoc
+    # prerequisite (see _get_vendor_location_prerequisites() in rules.py).
     "VendorCheck_BlsInaSe1Ripperdoc02_1": LocationData(display_name="Jackson Plains Ripperdoc (Stall 2) 1", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
     "VendorCheck_BlsInaSe1Ripperdoc02_2": LocationData(display_name="Jackson Plains Ripperdoc (Stall 2) 2", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="ripperdoc"),
     "VendorCheck_BlsInaSe1Ripperdoc02_3": LocationData(display_name="Jackson Plains Ripperdoc (Stall 2) 3", regions=("Badlands",), category=LocationCategory.VENDOR, progress_type=LocationProgressType.PRIORITY, vendor_subtype="ripperdoc"),
@@ -754,6 +764,24 @@ location_table: Dict[str, LocationData] = {
     "VendorCheck_CzConNetrunner_2": LocationData(display_name="Dogtown Netrunner 2", regions=("Dogtown",), category=LocationCategory.VENDOR, dlc_only=True, progress_type=LocationProgressType.EXCLUDED, vendor_subtype="netrunner"),
     "VendorCheck_CzConNetrunner_3": LocationData(display_name="Dogtown Netrunner 3", regions=("Dogtown",), category=LocationCategory.VENDOR, dlc_only=True, progress_type=LocationProgressType.PRIORITY, vendor_subtype="netrunner"),
 }
+
+
+# ===== JACKSON PLAINS RIPPERDOC CAMP-MOVE KEYS =====
+# The Aldecaldos camp (and its ripperdoc) relocates within Jackson Plains once the player
+# finishes Panam's side-quest chain (capstone: "Queen of the Highway"). Stall 1 is the
+# pre-move camp ripperdoc and becomes unreachable once the camp moves; Stall 2 is the
+# post-move camp ripperdoc and only exists after the move. Shared here so regions.py and
+# rules.py apply consistent, option-aware handling instead of duplicating literal keys.
+JACKSON_PLAINS_RIPPERDOC_STALL_1_KEYS = (
+    "VendorCheck_BlsInaSe1Ripperdoc01_1",
+    "VendorCheck_BlsInaSe1Ripperdoc01_2",
+    "VendorCheck_BlsInaSe1Ripperdoc01_3",
+)
+JACKSON_PLAINS_RIPPERDOC_STALL_2_KEYS = (
+    "VendorCheck_BlsInaSe1Ripperdoc02_1",
+    "VendorCheck_BlsInaSe1Ripperdoc02_2",
+    "VendorCheck_BlsInaSe1Ripperdoc02_3",
+)
 
 
 # ===== AUTO-ASSIGN LOCATION CODES =====

--- a/worlds/cyberpunk2077/regions.py
+++ b/worlds/cyberpunk2077/regions.py
@@ -4,7 +4,7 @@ Cyberpunk 2077 Region Definitions
 
 from typing import Dict, TYPE_CHECKING
 from BaseClasses import Region, Entrance, LocationProgressType
-from .locations import Cyberpunk2077Location, location_table, LocationCategory
+from .locations import Cyberpunk2077Location, location_table, LocationCategory, JACKSON_PLAINS_RIPPERDOC_STALL_2_KEYS
 from .options import (
     has_effective_phantom_liberty_dlc,
     is_goal_all_side_quests,
@@ -366,6 +366,13 @@ def create_region(world: "Cyberpunk2077World", region_name: str) -> Region:
             }
             subtype = location_data.vendor_subtype
             if subtype and not subtype_option_map.get(subtype):
+                continue
+            # Jackson Plains Ripperdoc (Stall 2) is the post-camp-move Aldecaldos
+            # ripperdoc: it only exists once Panam's side-quest chain has relocated
+            # the camp. Without side quests in the pool there is no way to gate it
+            # sanely, so it must not be populated at all (see rules.py for the
+            # Queen of the Highway gate applied when side quests are enabled).
+            if location_name in JACKSON_PLAINS_RIPPERDOC_STALL_2_KEYS and not side_quests_enabled:
                 continue
 
         # Skip DLC locations if the player didn't enable them

--- a/worlds/cyberpunk2077/rules.py
+++ b/worlds/cyberpunk2077/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, TypeAlias
 from BaseClasses import CollectionState
 from worlds.generic.Rules import add_rule, set_rule
-from .locations import location_table, LocationCategory
+from .locations import location_table, LocationCategory, JACKSON_PLAINS_RIPPERDOC_STALL_2_KEYS
 from .options import CompletionGoal, get_gated_major_districts, has_effective_phantom_liberty_dlc
 
 if TYPE_CHECKING:
@@ -201,6 +201,13 @@ def _get_vendor_location_prerequisites(world: "Cyberpunk2077World") -> dict[str,
         loc_data = location_table[internal_key]
         subtype = loc_data.vendor_subtype
         if subtype and not subtype_option_map.get(subtype):
+            continue
+        # Jackson Plains Ripperdoc (Stall 2) only exists post-camp-move, which requires
+        # completing Panam's side-quest chain (capstone "Queen of the Highway"). It is only
+        # in the pool when side quests are enabled (see regions.py), so this edge is inert
+        # otherwise.
+        if internal_key in JACKSON_PLAINS_RIPPERDOC_STALL_2_KEYS:
+            edges[loc_data.display_name] = ("Prologue - The Ripperdoc", "Queen of the Highway")
             continue
         edges[loc_data.display_name] = "Prologue - The Ripperdoc"
     return edges

--- a/worlds/cyberpunk2077/test/test_vendor_sanity.py
+++ b/worlds/cyberpunk2077/test/test_vendor_sanity.py
@@ -1,3 +1,5 @@
+from BaseClasses import LocationProgressType
+
 from .bases import Cyberpunk2077TestBase
 from ..rules import get_active_location_prerequisites
 
@@ -20,4 +22,92 @@ class TestVendorSanityRules(Cyberpunk2077TestBase):
     def test_other_vendor_subtypes_are_filtered_out(self) -> None:
         edges = get_active_location_prerequisites(self.world)
         self.assertNotIn("2nd Amendment Shop 1", edges)
+
+
+# Jackson Plains Ripperdoc Stall 1/2 model the Aldecaldos camp relocation: Stall 1 is the
+# pre-move camp ripperdoc (missable once "Queen of the Highway" completes), Stall 2 is the
+# post-move camp ripperdoc (only exists once side quests -- and therefore Panam's chain --
+# are included in generation).
+STALL_1_LOCATION_NAMES = (
+    "Jackson Plains Ripperdoc (Stall 1) 1",
+    "Jackson Plains Ripperdoc (Stall 1) 2",
+    "Jackson Plains Ripperdoc (Stall 1) 3",
+)
+STALL_2_LOCATION_NAMES = (
+    "Jackson Plains Ripperdoc (Stall 2) 1",
+    "Jackson Plains Ripperdoc (Stall 2) 2",
+    "Jackson Plains Ripperdoc (Stall 2) 3",
+)
+
+VENDOR_SANITY_RIPPERDOC_ONLY_OPTIONS = {
+    "vendor_sanity": 1,
+    "vendor_ripperdocs": 1,
+    "vendor_gunsmiths": 0,
+    "vendor_clothing": 0,
+    "vendor_melee": 0,
+    "vendor_netrunners": 0,
+}
+
+
+class TestJacksonPlainsRipperdocStallsDefaultGoal(Cyberpunk2077TestBase):
+    """Default goal has no side quests, so Panam's chain (and the camp move) never happens."""
+
+    run_default_tests = False
+    options = {
+        **VENDOR_SANITY_RIPPERDOC_ONLY_OPTIONS,
+        "completion_goal": 0,
+    }
+
+    def test_stall_2_is_not_populated(self) -> None:
+        location_names = {loc.name for loc in self.multiworld.get_locations(self.player)}
+        for name in STALL_2_LOCATION_NAMES:
+            self.assertNotIn(name, location_names)
+
+    def test_stall_2_has_no_active_prerequisite_edge(self) -> None:
+        edges = get_active_location_prerequisites(self.world)
+        for name in STALL_2_LOCATION_NAMES:
+            self.assertNotIn(name, edges)
+
+    def test_stall_1_is_populated_and_excluded(self) -> None:
+        for name in STALL_1_LOCATION_NAMES:
+            location = self.multiworld.get_location(name, self.player)
+            self.assertEqual(location.progress_type, LocationProgressType.EXCLUDED)
+
+
+class TestJacksonPlainsRipperdocStallsAllSideQuestsGoal(Cyberpunk2077TestBase):
+    run_default_tests = False
+    options = {
+        **VENDOR_SANITY_RIPPERDOC_ONLY_OPTIONS,
+        "completion_goal": 1,
+    }
+
+    def test_stall_2_is_populated(self) -> None:
+        location_names = {loc.name for loc in self.multiworld.get_locations(self.player)}
+        for name in STALL_2_LOCATION_NAMES:
+            self.assertIn(name, location_names)
+
+    def test_stall_1_remains_excluded(self) -> None:
+        for name in STALL_1_LOCATION_NAMES:
+            location = self.multiworld.get_location(name, self.player)
+            self.assertEqual(location.progress_type, LocationProgressType.EXCLUDED)
+
+    def test_stall_2_requires_prologue_and_queen_of_the_highway(self) -> None:
+        edges = get_active_location_prerequisites(self.world)
+        for name in STALL_2_LOCATION_NAMES:
+            self.assertEqual(edges[name], ("Prologue - The Ripperdoc", "Queen of the Highway"))
+
+    def test_stall_2_unreachable_without_district_access(self) -> None:
+        # Badlands is only reachable via Westbrook or Santo Domingo, both restricted by
+        # default -- with no items collected, Stall 2 must be unreachable.
+        for name in STALL_2_LOCATION_NAMES:
+            self.assertFalse(self.can_reach_location(name))
+
+    def test_stall_2_reachable_once_badlands_access_and_queen_chain_resolve(self) -> None:
+        # Collecting only the district tokens needed to physically reach Badlands (no
+        # item gates Panam's chain itself) proves the AND-tuple prerequisite resolves
+        # end-to-end against real location names, catching typos/broken references.
+        self.collect_by_name("Westbrook Access Token")
+        self.collect_by_name("Badlands Access Token")
+        for name in STALL_2_LOCATION_NAMES:
+            self.assertTrue(self.can_reach_location(name))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Accounts for the Aldecaldos camp relocation in generation logic for the Jackson Plains Ripperdoc vendor checks:

- **Stall 2** (post-camp-move ripperdoc) only exists once side quests are enabled (`Complete Any Ending W/ All Side Quests`), and is gated behind both `Prologue - The Ripperdoc` and `Queen of the Highway` (the quest that relocates the camp). If side quests are disabled, Stall 2 is omitted entirely from generation rather than being left unreachable/undefined.
- **Stall 1** (pre-camp-move ripperdoc) becomes permanently unreachable in-game once the player finishes Panam's chain and the camp moves, so it's marked fully `EXCLUDED` (no progression items placed there). The client now auto-releases any unchecked Stall 1 vendor checks once "Queen of the Highway" completes, mirroring the existing NG+ prologue multi-release pattern, so a vendor-sanity run never gets permanently stuck on a location the player can no longer reach in-game. This release also runs on every spawn (guarded by the quest's completion fact) to cover saves where the quest finished before reconnecting.

## Changes

- `worlds/cyberpunk2077/locations.py`: mark Stall 1 slots `EXCLUDED`; add shared `JACKSON_PLAINS_RIPPERDOC_STALL_{1,2}_KEYS` constants and doc comments.
- `worlds/cyberpunk2077/regions.py`: omit Stall 2 from region population when side quests are disabled.
- `worlds/cyberpunk2077/rules.py`: add `Queen of the Highway` as an additional AND prerequisite for Stall 2.
- `worlds/cyberpunk2077/test/test_vendor_sanity.py`: new tests covering both completion goals.
- `Cyberpunk2077/.../APConstants.reds`, `APGameSystem.reds`: add `ReleaseJacksonPlainsRipperdocStall1Checks`, called from the quest-completion journal hook and on spawn.

## Testing

Ran the full `worlds/cyberpunk2077` Python test suite against a fresh Archipelago core checkout (linked via symlink) with `pytest`. All new tests pass; the only failures are 4 pre-existing, seed-dependent `test_fill` flakes reproducible on the base branch without any of these changes (confirmed via `git stash` comparison).

No native/RedScript build was performed (no local RED4ext toolchain in this environment) — the client-side changes follow the exact pattern of the existing `APNGPlusBridge` prologue release logic.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2515e4b-57a2-4806-84e9-103a976d786b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2515e4b-57a2-4806-84e9-103a976d786b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

