### PR TITLE
Port district Access Token softlock fix to feature/v07

### DIFF
--- a/Cyberpunk2077/bin/x64/plugins/cyber_engine_tweaks/mods/Cyberpunk_Archipelago_Bridge/init.lua
+++ b/Cyberpunk2077/bin/x64/plugins/cyber_engine_tweaks/mods/Cyberpunk_Archipelago_Bridge/init.lua
@@ -17,7 +17,10 @@ local isOverlayOpen = false
 local connectionStatus = "DISCONNECTED"
 local statusMessage = "Not connected"
 local connectAttemptStartedAt = nil
-local connectTimeoutSeconds = 10
+-- Must comfortably exceed the native retry/SSL-fallback window (wss:// attempt, a few retries,
+-- then ws:// fallback) so a transient errno-0 "Connect error: Success" during that window doesn't
+-- get read as a final failure before the native layer has a chance to recover.
+local connectTimeoutSeconds = 30
 
 local pumpAccumulator = 0.0
 local pumpIntervalSeconds = 0.05
@@ -261,22 +264,25 @@ local function updateConnectionStatus(apService)
     end
 
     if connectionStatus == "CONNECTING" then
-        if lastConnectionError ~= "" then
+        -- Do NOT treat a non-empty lastConnectionError as final here. The native layer reports
+        -- transient websocket errors (including a misleading errno-0 "Connect error: Success")
+        -- while it is still retrying / falling back from wss:// to ws://, and status stays
+        -- "refused" (handled above) or times out (handled below) once the attempt truly fails.
+        -- Bailing out on the first transient error message previously caused the connection to
+        -- appear permanently "DISCONNECTED - ... Connect error: Success" even when the native
+        -- retry/fallback would have succeeded shortly after.
+        local elapsedSeconds = connectAttemptStartedAt and (os.clock() - connectAttemptStartedAt) or 0
+        if elapsedSeconds >= connectTimeoutSeconds then
+            pcall(function()
+                apService:DisconnectFromCET()
+            end)
             connectionStatus = "DISCONNECTED"
             connectAttemptStartedAt = nil
-            statusMessage = lastConnectionError
+            statusMessage = lastConnectionError ~= "" and lastConnectionError or "Connection timed out. Verify host, port, and slot."
+        elseif lastConnectionError ~= "" then
+            statusMessage = "Connecting... (" .. lastConnectionError .. ")"
         else
-            local elapsedSeconds = connectAttemptStartedAt and (os.clock() - connectAttemptStartedAt) or 0
-            if elapsedSeconds >= connectTimeoutSeconds then
-                pcall(function()
-                    apService:DisconnectFromCET()
-                end)
-                connectionStatus = "DISCONNECTED"
-                connectAttemptStartedAt = nil
-                statusMessage = "Connection timed out. Verify host, port, and slot."
-            else
-                statusMessage = statusText ~= "" and statusText or "Connecting..."
-            end
+            statusMessage = statusText ~= "" and statusText or "Connecting..."
         end
         return
     end

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APDistrictManager.reds
@@ -45,8 +45,15 @@ public class APDistrictManager extends ScriptableSystem {
             APLogger.LogDebug("APDistrictManager: Quest handler not initialized");
             return;
         }
-        this.questHandler.SetQuestKey(districtId);
-        APLogger.LogInfo(s"District unlocked: \(districtId)");
+
+        // Only report success when the quest fact write actually succeeded - previously this logged
+        // "District unlocked" unconditionally, which was misleading when SetQuestKey failed (e.g. the
+        // quest system wasn't available yet), leaving the district silently still locked.
+        if this.questHandler.SetQuestKey(districtId) {
+            APLogger.LogInfo(s"District unlocked: \(districtId)");
+        } else {
+            APLogger.LogError(s"APDistrictManager: Failed to unlock district \(districtId) - quest system not available");
+        }
     }
 
     // Handle district restriction (called when player enters locked district)
@@ -63,6 +70,18 @@ public class APDistrictManager extends ScriptableSystem {
 
         // Don't enforce during lifepath intro
         if !this.questHandler.IsPassedPrologue() {
+            return;
+        }
+
+        // Don't teleport while a post-spawn/connect item resync is still draining - the quest facts
+        // HasQuestKey reads below may not yet reflect district tokens the player already owns (see
+        // APGameState.itemResyncPending / TCPClient.ArmItemResyncPending). This is what caused the
+        // softlock: after a save reload, SyncData ran with an empty/incomplete item list, and
+        // entering a district before the AP item backlog finished replaying got the player kicked
+        // out of a district they actually owned the token for.
+        let resyncGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        if IsDefined(resyncGameState) && resyncGameState.IsItemResyncPending() {
+            APLogger.LogInfo("APDistrictManager: Deferring district enforcement - item resync still in progress");
             return;
         }
 

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameState.reds
@@ -38,8 +38,21 @@ public class APGameState extends ScriptableService {
     // This matches Python's len(received_items) counting for SYNC_COMPLETE
     public let totalNetworkItemsReceived: Int32;
 
-    private func OnAttach() -> Void {
-        this.items = new APItemList();
+    // True while a post-spawn/connect item resync is in flight (TCPClient is still draining the
+    // native item queue after a save load or fresh connect). District enforcement should not
+    // teleport the player while this is set, since the quest facts it reads may not reflect
+    // already-owned tokens yet - see APDistrictManager.HandleDistrictRestriction.
+    public let itemResyncPending: Bool;
+
+    // ScriptableService's lifecycle callback is OnLoad (runs once when the game starts, independent
+    // of save load/unload) - NOT OnAttach, which is a ScriptableSystem callback for save-bound
+    // singletons. Using OnAttach here meant this never ran, so `items` stayed undefined and every
+    // SyncData() call after a save reload silently aborted, preventing already-owned district
+    // tokens from being re-applied and causing softlocks.
+    private func OnLoad() -> Void {
+        if !IsDefined(this.items) {
+            this.items = new APItemList();
+        }
         APLogger.LogInfo("Cyberpunk 2077 Archipelago Game State Ready");
     }
 
@@ -54,8 +67,22 @@ public class APGameState extends ScriptableService {
 
     // ===== SIMPLE GETTERS/SETTERS ONLY =====
 
+    // Lazy-initializes `items` as a defensive fallback in case this is ever called before OnLoad
+    // has run, so callers never have to null-check the result.
     public func GetItems() -> ref<APItemList> {
+        if !IsDefined(this.items) {
+            APLogger.LogDebug("APGameState: Lazy-creating item list");
+            this.items = new APItemList();
+        }
         return this.items;
+    }
+
+    public func IsItemResyncPending() -> Bool {
+        return this.itemResyncPending;
+    }
+
+    public func SetItemResyncPending(value: Bool) -> Void {
+        this.itemResyncPending = value;
     }
 
     public func DiedFromDeathLink() -> Void {

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APGameSystem.reds
@@ -61,8 +61,20 @@ public class APGameSystem extends ScriptableSystem {
 
     public func SyncData() -> Void {
         let APGameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        if !IsDefined(APGameState) {
+            APLogger.LogDebug("APGameSystem: Cannot sync data - game state not available");
+            return;
+        }
+
+        // Handlers are cached in OnAttach; ScriptableSystems (and this cache) are recreated on every
+        // save load, so guard against SyncData running before OnAttach has resolved them.
+        if !IsDefined(this.inventoryHandler) || !IsDefined(this.questHandler) {
+            APLogger.LogDebug("APGameSystem: Cannot sync data - inventory/quest handler not available");
+            return;
+        }
+
         let gameStateItems: ref<APItemList> = APGameState.GetItems();
-        APLogger.LogInfo("Starting Item Sync");
+        APLogger.LogInfo(s"Starting Item Sync - \(ArraySize(gameStateItems.Items)) tracked item(s)");
 
         for item in gameStateItems.Items { 
             // Try to get the item from the FactsDB
@@ -238,7 +250,9 @@ public class APGameSystem extends ScriptableSystem {
         let progressionLevel: Int32 = this.inventoryHandler.GetItemFactCount(item) + 1;
         let resolvedItem: String = APItemProgression.GetProgressiveItem(item, progressionLevel);
         this.AddInventoryItem(resolvedItem);
-        APGameState.items.AddItem(resolvedItem, 1);
+        if IsDefined(APGameState) {
+            APGameState.GetItems().AddItem(resolvedItem, 1);
+        }
         this.inventoryHandler.IncrementItemFact(item, 1);
     }
 
@@ -330,8 +344,13 @@ public class APGameSystem extends ScriptableSystem {
         }
     }
 
+    // Re-applies an already-seen network item (i.e. one the server is resending on reconnect that
+    // was already applied during a prior connection). This must never re-trigger one-shot effects
+    // like traps, but progression state (quest keys, district tokens, weapon passes) is safe - and
+    // necessary - to reconcile here, since it recovers grants that never made it into a quest fact
+    // the first time (e.g. the item arrived before the world/quest system was ready).
     public func HandleItemSync(item: String, gameState: ref<APGameState>) -> Void {
-        if !IsDefined(gameState) || !IsDefined(gameState.items) {
+        if !IsDefined(gameState) {
             return;
         }
 
@@ -341,13 +360,16 @@ public class APGameSystem extends ScriptableSystem {
 
         APLogger.LogDebug(s"APGameSystem: Item received from AP server (sync): \(item)");
 
+        // GetItems() lazily creates the list if needed, so this is never null.
+        let items: ref<APItemList> = gameState.GetItems();
+
         // Increment NetworkItem counter for each item processed (matches Python's len(received_items))
         gameState.totalNetworkItemsReceived += 1;
 
         // Always add to persistent storage first so items can be re-synced on save load
         if APItemParser.IsQuestKey(item) {
             // Quest keys are tracked even though they're binary (0 or 1)
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
             this.AddQuestKey(item);
         }
         else if APItemParser.IsTrap(item) {
@@ -356,22 +378,24 @@ public class APGameSystem extends ScriptableSystem {
         }
         else if APItemParser.IsEddies(item) {
             let amount: Int32 = APItemParser.ParseEddiesAmount(item);
-            gameState.items.AddItem(APConstants.GetMoneyItemId(), amount);
+            items.AddItem(APConstants.GetMoneyItemId(), amount);
         }
         else if APItemParser.IsInventoryItem(item) {
             let itemId: String = APItemParser.ParseInventoryItemId(item);
-            gameState.items.AddItem(itemId, 1);
+            items.AddItem(itemId, 1);
         }
         else if APItemParser.IsProgressiveItem(item) {
             // Track progressive items so they can be re-synced on save load
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
         }
         else if APItemParser.IsDistrictToken(item) {
-            // Track district tokens so they can be re-synced on save load
-            gameState.items.AddItem(item, 1);
+            // Track district tokens so they can be re-synced on save load, and retry the unlock in
+            // case the quest fact never got written the first time this item was received.
+            items.AddItem(item, 1);
+            this.HandleDistrictUnlock(item);
         }
         else if APItemParser.IsWeaponAuthorization(item) {
-            gameState.items.AddItem(item, 1);
+            items.AddItem(item, 1);
             this.HandleWeaponUnlock(item);
         }
         // Note: Skill points and traps not added as they're not fully implemented
@@ -386,14 +410,17 @@ public class APGameSystem extends ScriptableSystem {
 
         APLogger.LogDebug(s"APGameSystem: Item received from AP server: \(item)");
 
-        // Increment NetworkItem counter for real-time items from queue worker
+        // GetItems() lazily creates the list if needed, so items is never null once gameState is defined.
+        let items: ref<APItemList>;
         if IsDefined(APGameState) {
+            items = APGameState.GetItems();
+            // Increment NetworkItem counter for real-time items from queue worker
             APGameState.totalNetworkItemsReceived += 1;
         }
 
         if APItemParser.IsQuestKey(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.AddQuestKey(item);
         }
@@ -408,33 +435,33 @@ public class APGameSystem extends ScriptableSystem {
         }
         else if APItemParser.IsEddies(item) {
             let amount: Int32 = APItemParser.ParseEddiesAmount(item);
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(APConstants.GetMoneyItemId(), amount);
+            if IsDefined(items) {
+                items.AddItem(APConstants.GetMoneyItemId(), amount);
             }
             this.AddEddies(amount);
         }
         else if APItemParser.IsInventoryItem(item) {
             let itemId: String = APItemParser.ParseInventoryItemId(item);
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(itemId, 1);
+            if IsDefined(items) {
+                items.AddItem(itemId, 1);
             }
             this.AddInventoryItem(itemId);
         }
         else if APItemParser.IsProgressiveItem(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.HandleProgressiveItem(item);
         }
         else if APItemParser.IsDistrictToken(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.HandleDistrictUnlock(item);
         }
         else if APItemParser.IsWeaponAuthorization(item) {
-            if IsDefined(APGameState.items) {
-                APGameState.items.AddItem(item, 1);
+            if IsDefined(items) {
+                items.AddItem(item, 1);
             }
             this.HandleWeaponUnlock(item);
         }
@@ -485,6 +512,15 @@ protected cb func OnMakePlayerVisibleAfterSpawn(evt: ref<EndGracePeriodAfterSpaw
     if IsDefined(APGameState) {
         //APLogger.LogInfo( "AP Game State Defined");
         APGameState.HandlePlayerRespawn();
+
+        // Defer district enforcement until the post-spawn item backlog (if connected) has been
+        // fully drained by TCPClient.Pump - see APGameState.itemResyncPending. Must happen before
+        // SyncData so any DistrictEnteredEvent firing immediately after spawn is already covered.
+        let tcpClient: ref<TCPClient> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.TCPClient") as TCPClient;
+        if IsDefined(tcpClient) {
+            tcpClient.OnPlayerSpawned();
+        }
+
         APGameSystem.SyncData();
         APNGPlusBridge.TryReleasePrologueChecksOnSpawn(GetGameInstance());
         APGameSystem.SendSyncChecks();

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/APWeaponRestrictionEnforcer.reds
@@ -2,8 +2,10 @@ module Archipelago
 
 public class APWeaponRestrictionEnforcer extends ScriptableService {
 
-    private func OnAttach() -> Void {
-        APLogger.LogInfo("APWeaponRestrictionEnforcer attached and ready");
+    // ScriptableService's lifecycle callback is OnLoad, not OnAttach (that's for ScriptableSystem) -
+    // see APGameState.OnLoad for details on why this matters.
+    private func OnLoad() -> Void {
+        APLogger.LogInfo("APWeaponRestrictionEnforcer loaded and ready");
     }
 
     // This function is called by the game's equipment system when checking if a weapon can be equipped

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -9,6 +9,17 @@ public class TCPClient extends ScriptableService {
     private let lastConnectionError: String = "";
     private let chatMessages: array<String>;
 
+    // Tracks APGameSystem availability across Pump ticks so we can log only on transitions
+    // (Pump runs ~20x/sec, so logging every tick would flood scripting.log).
+    private let lastGameSystemAvailableLogged: Bool = false;
+    private let hasLoggedGameSystemAvailability: Bool = false;
+
+    // Settle-tracking for APGameState.itemResyncPending (see ArmItemResyncPending). Counts Pump
+    // ticks since pending was armed, and consecutive ticks with no item queue activity, so we know
+    // when the post-spawn/connect backlog has finished draining and district enforcement can resume.
+    private let ticksSincePendingSet: Int32 = 0;
+    private let emptyPollStreakWhilePending: Int32 = 0;
+
     public func Configure(server: String, game: String, slot: String, pass: String) -> Void {
         this.serverAddress = server;
         this.gameName = game;
@@ -200,6 +211,32 @@ public class TCPClient extends ScriptableService {
         return AP_Say(text);
     }
 
+    // Marks a district-enforcement deferral window: APDistrictManager.HandleDistrictRestriction will
+    // not teleport the player while APGameState.itemResyncPending is set, since quest facts read
+    // during this window may not yet reflect tokens the player already owns (the native item queue
+    // is still being drained by Pump after a save load or fresh connect). Resets the settle counters
+    // so Pump starts watching for the queue to go quiet again.
+    private func ArmItemResyncPending() -> Void {
+        let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+        if !IsDefined(gameState) {
+            return;
+        }
+        if !gameState.IsItemResyncPending() {
+            APLogger.LogDebug("TCPClient: Arming item resync pending - deferring district enforcement until item queue settles");
+        }
+        gameState.SetItemResyncPending(true);
+        this.ticksSincePendingSet = 0;
+        this.emptyPollStreakWhilePending = 0;
+    }
+
+    // Called once per spawn (from APGameSystem's OnMakePlayerVisibleAfterSpawn hook) so enforcement
+    // is deferred as soon as possible after a save load, before any DistrictEnteredEvent can fire.
+    public func OnPlayerSpawned() -> Void {
+        if this.IsConnected() {
+            this.ArmItemResyncPending();
+        }
+    }
+
     public func Pump() -> Void {
         AP_ProcessConnectionAttempt();
         if this.initialized {
@@ -211,11 +248,14 @@ public class TCPClient extends ScriptableService {
             }
         }
 
+        // Fetched once up front and reused for both the slot-config mirroring below and the
+        // item-resync-pending settle tracking at the end of this function.
+        let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
+
         // Apply slot config received from the server (e.g. district restriction).
         // The native bridge captures these from the Connected packet's slot_data;
         // mirror them into APGameState so enforcement can read them.
         if this.IsConnected() {
-            let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
             if IsDefined(gameState) {
                 let changed: Bool = gameState.SetDistrictRestrictionConfig(
                     AP_GetRestrictByMajorDistrict(),
@@ -271,23 +311,51 @@ public class TCPClient extends ScriptableService {
 
         // Poll item queue from APCpp.
         // Item ID -> in-game mapping is handled in RedScript via APNativeMappings.ResolveItemId.
-        let nextItemId: Int64 = AP_PollItemQueue();
-        if nextItemId >= 0l {
-            let itemId: String = APNativeMappings.ResolveItemId(nextItemId);
-            if StrLen(itemId) > 0 {
-                let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
-                if IsDefined(gameSystem) {
+        //
+        // Only poll while APGameSystem is available (i.e. a save is loaded). Polling from the main
+        // menu or before the world is ready would pop the item off the native queue with nowhere to
+        // apply it, permanently losing it even though the server considers it delivered. Leaving it
+        // queued here means it's applied as soon as a save is loaded and Pump runs again.
+        let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+        let gameSystemAvailable: Bool = IsDefined(gameSystem);
+        // Bool has no != overload in RedScript - use an XOR-style comparison.
+        let gameSystemAvailabilityChanged: Bool = (gameSystemAvailable && !this.lastGameSystemAvailableLogged) || (!gameSystemAvailable && this.lastGameSystemAvailableLogged);
+        if !this.hasLoggedGameSystemAvailability || gameSystemAvailabilityChanged {
+            APLogger.LogDebug(s"TCPClient.Pump: APGameSystem availability changed -> \(gameSystemAvailable)");
+            if !gameSystemAvailable {
+                APLogger.LogDebug("TCPClient.Pump: item queue will not be polled/drained until a save is loaded");
+            } else if this.IsConnected() {
+                // The system can become available without a fresh spawn callback (e.g. it attaches
+                // right as Pump runs). Defer enforcement here too, same as OnPlayerSpawned.
+                APLogger.LogDebug("TCPClient.Pump: APGameSystem became available while connected - deferring district enforcement until item queue settles");
+                this.ArmItemResyncPending();
+            }
+            this.lastGameSystemAvailableLogged = gameSystemAvailable;
+            this.hasLoggedGameSystemAvailability = true;
+        }
+
+        let itemAppliedThisTick: Bool = false;
+        if IsDefined(gameSystem) {
+            let nextItemId: Int64 = AP_PollItemQueue();
+            if nextItemId >= 0l {
+                let itemId: String = APNativeMappings.ResolveItemId(nextItemId);
+                if StrLen(itemId) > 0 {
+                    itemAppliedThisTick = true;
                     let networkIndex: Int32 = AP_GetPolledItemNetworkIndex();
                     let shouldNotify: Bool = AP_GetPolledItemShouldNotify();
                     let shouldGrant: Bool = true;
                     let inventoryHandler: ref<APInventoryHandler> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APInventoryHandler") as APInventoryHandler;
-                    let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
 
+                    // If this item's network index is older than the last one we already applied
+                    // live, the server is resending something we've already processed (typically on
+                    // reconnect). Route it through the sync path instead of granting it again, so
+                    // one-shot effects (traps) don't replay and inventory/eddies aren't duplicated -
+                    // while still letting durable state (quest keys, district tokens) reconcile.
                     if networkIndex >= 0 && IsDefined(inventoryHandler) {
                         let lastProcessedIndex: Int32 = inventoryHandler.GetLastNetworkItemIndex();
                         if networkIndex < lastProcessedIndex {
                             shouldGrant = false;
-                            if IsDefined(gameState) && gameState.totalNetworkItemsReceived < lastProcessedIndex {
+                            if IsDefined(gameState) {
                                 gameSystem.HandleItemSync(itemId, gameState);
                             }
                         }
@@ -314,9 +382,36 @@ public class TCPClient extends ScriptableService {
                     } else {
                         APLogger.LogDebug(s"TCPClient: Skipped already-processed AP item at network index \(ToString(networkIndex))");
                     }
+                } else {
+                    APLogger.LogDebug(s"TCPClient: No item mapping for AP item ID \(ToString(nextItemId))");
                 }
+            }
+        }
+
+        // Settle tracking for APGameState.itemResyncPending (see ArmItemResyncPending). Once the
+        // item queue has gone quiet for a bit (or a hard timeout elapses as a safety net), re-run
+        // SyncData once more to catch anything the backlog just delivered, then let district
+        // enforcement resume.
+        if IsDefined(gameState) && gameState.IsItemResyncPending() {
+            this.ticksSincePendingSet += 1;
+            if itemAppliedThisTick {
+                this.emptyPollStreakWhilePending = 0;
             } else {
-                APLogger.LogDebug(s"TCPClient: No item mapping for AP item ID \(ToString(nextItemId))");
+                this.emptyPollStreakWhilePending += 1;
+            }
+
+            let emptyPollSettleThreshold: Int32 = 40; // ~2s of no new items at ~20 Pump ticks/sec
+            let pendingHardTimeoutTicks: Int32 = 600; // ~30s safety net so enforcement can't stay off forever
+            if this.emptyPollStreakWhilePending >= emptyPollSettleThreshold || this.ticksSincePendingSet >= pendingHardTimeoutTicks {
+                APLogger.LogInfo(
+                    s"TCPClient.Pump: item queue settled (emptyPollStreak=\(this.emptyPollStreakWhilePending), ticksSincePending=\(this.ticksSincePendingSet)) - resuming district enforcement"
+                );
+                gameState.SetItemResyncPending(false);
+                this.ticksSincePendingSet = 0;
+                this.emptyPollStreakWhilePending = 0;
+                if IsDefined(gameSystem) {
+                    gameSystem.SyncData();
+                }
             }
         }
 

--- a/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
+++ b/Cyberpunk2077/r6/scripts/CyberPunkArchipelago/Cyberpunk2077_Archipelago_Client/TCPClient.reds
@@ -242,7 +242,15 @@ public class TCPClient extends ScriptableService {
         if this.initialized {
             let status: Int32 = AP_GetConnectionStatus();
             let nativeError: String = AP_GetLastConnectionError();
-            if status == 0 && StrLen(nativeError) > 0 {
+            // APBridge::GetLastConnectionError suppresses transient websocket-level errors (e.g.
+            // an errno/WSA-0 "Connect error: Success" during the wss:// -> ws:// retry/fallback
+            // window) while a connect attempt is still active, only surfacing a non-empty error
+            // once the attempt has genuinely ended (refused or timed out). Filter defensively here
+            // too in case an older native build without that suppression is still installed - this
+            // block previously latched `initialized = false` on the very first transient error,
+            // which permanently stuck the UI on "DISCONNECTED - ... Connect error: Success" even
+            // though the underlying retry/fallback would otherwise have succeeded.
+            if status == 0 && StrLen(nativeError) > 0 && !StrContains(nativeError, "Success") {
                 this.lastConnectionError = nativeError;
                 this.initialized = false;
             }
@@ -250,6 +258,7 @@ public class TCPClient extends ScriptableService {
 
         // Fetched once up front and reused for both the slot-config mirroring below and the
         // item-resync-pending settle tracking at the end of this function.
+        let systems: ref<ScriptableSystemsContainer> = GetGameInstance().GetScriptableSystemsContainer();
         let gameState: ref<APGameState> = GameInstance.GetScriptableServiceContainer().GetService(n"Archipelago.APGameState") as APGameState;
 
         // Apply slot config received from the server (e.g. district restriction).
@@ -269,7 +278,10 @@ public class TCPClient extends ScriptableService {
                         s"District restriction config received: major=\(gameState.restrictByMajorDistrict), sub=\(gameState.restrictBySubDistrict), gated=\(gatedSummary), auto_open=\(autoOpenSummary)"
                     );
 
-                    let districtGameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+                    let districtGameSystem: ref<APGameSystem>;
+                    if IsDefined(systems) {
+                        districtGameSystem = systems.Get(n"Archipelago.APGameSystem") as APGameSystem;
+                    }
                     if IsDefined(districtGameSystem) {
                         districtGameSystem.ApplyDistrictRestrictionConfig();
                     }
@@ -316,7 +328,14 @@ public class TCPClient extends ScriptableService {
         // menu or before the world is ready would pop the item off the native queue with nowhere to
         // apply it, permanently losing it even though the server considers it delivered. Leaving it
         // queued here means it's applied as soon as a save is loaded and Pump runs again.
-        let gameSystem: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+        //
+        // `systems` itself may be null (e.g. before the world is fully initialized) - guard the
+        // lookup so a transient null container can't abort the rest of Pump (connection handling
+        // above has already run by this point regardless).
+        let gameSystem: ref<APGameSystem>;
+        if IsDefined(systems) {
+            gameSystem = systems.Get(n"Archipelago.APGameSystem") as APGameSystem;
+        }
         let gameSystemAvailable: Bool = IsDefined(gameSystem);
         // Bool has no != overload in RedScript - use an XOR-style comparison.
         let gameSystemAvailabilityChanged: Bool = (gameSystemAvailable && !this.lastGameSystemAvailableLogged) || (!gameSystemAvailable && this.lastGameSystemAvailableLogged);
@@ -344,7 +363,10 @@ public class TCPClient extends ScriptableService {
                     let networkIndex: Int32 = AP_GetPolledItemNetworkIndex();
                     let shouldNotify: Bool = AP_GetPolledItemShouldNotify();
                     let shouldGrant: Bool = true;
-                    let inventoryHandler: ref<APInventoryHandler> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APInventoryHandler") as APInventoryHandler;
+                    let inventoryHandler: ref<APInventoryHandler>;
+                    if IsDefined(systems) {
+                        inventoryHandler = systems.Get(n"Archipelago.APInventoryHandler") as APInventoryHandler;
+                    }
 
                     // If this item's network index is older than the last one we already applied
                     // live, the server is resending something we've already processed (typically on
@@ -424,7 +446,10 @@ public class TCPClient extends ScriptableService {
 
         if AP_IsDeathLinkPending() {
             APLogger.LogDebug("DeathLink: inbound pending — attempting HandleDeathLink");
-            let gameSystemDL: ref<APGameSystem> = GetGameInstance().GetScriptableSystemsContainer().Get(n"Archipelago.APGameSystem") as APGameSystem;
+            let gameSystemDL: ref<APGameSystem>;
+            if IsDefined(systems) {
+                gameSystemDL = systems.Get(n"Archipelago.APGameSystem") as APGameSystem;
+            }
             if !IsDefined(gameSystemDL) {
                 APLogger.LogDebug("DeathLink: inbound deferred — APGameSystem undefined");
             } else if gameSystemDL.HandleDeathLink() {

--- a/native/APCpp/Archipelago.cpp
+++ b/native/APCpp/Archipelago.cpp
@@ -185,7 +185,12 @@ void AP_Init(const char* ip, const char* game, const char* player_name, const ch
                     last_connection_error = "Unable to connect to Archipelago server.";
                 }
                 printf("AP: Error connecting to Archipelago. Retries: %d\n", msg->errorInfo.retries-1);
-                if (msg->errorInfo.retries-1 >= 2 && isSSL && !ssl_success) {
+                // Fall back to plaintext ws:// on the very first failed wss:// attempt rather than
+                // waiting for several retries. A failed TLS handshake is frequently reported by
+                // IXWebSocket with an errno/WSA value of 0 (rendered as "Connect error: Success" by
+                // strerror), which is easy to mistake for a real/terminal error; recovering to
+                // ws:// immediately minimizes how long that misleading message can stick around.
+                if (msg->errorInfo.retries-1 >= 0 && isSSL && !ssl_success) {
                     printf("AP: SSL connection failed. Attempting unencrypted...\n");
                     webSocket.setUrl("ws://" + ap_ip);
                     isSSL = false;

--- a/native/cyberpunk_ap_plugin/src/APBridge.cpp
+++ b/native/cyberpunk_ap_plugin/src/APBridge.cpp
@@ -5,7 +5,10 @@
 
 namespace
 {
-constexpr auto kConnectAttemptTimeout = std::chrono::seconds(10);
+// Must comfortably exceed APCpp's wss:// -> ws:// fallback window (a few retries on wss:// before
+// falling back to plaintext), so a transient SSL/websocket hiccup doesn't get shut down here before
+// the fallback has a chance to succeed.
+constexpr auto kConnectAttemptTimeout = std::chrono::seconds(30);
 constexpr char kConnectTimeoutMessage[] = "Connection timed out. Verify host, port, and slot.";
 
 std::string NormalizeSlotDataRawString(std::string rawValue)
@@ -245,6 +248,19 @@ std::string APBridge::GetLastConnectionError() const
         return m_localConnectionError;
     }
     if (!m_initialized) return "";
+    if (m_connectAttemptActive)
+    {
+        // APCpp's raw last-connection-error is updated on every websocket Error/Close event,
+        // including transient ones during the wss:// -> ws:// retry/fallback sequence (IXWebSocket
+        // reports these with an errno/WSA value of 0, which strerror renders as "Success" - hence
+        // the confusing "Connect error: Success" message). Surfacing that here while an attempt is
+        // still active makes RedScript/CET treat a mid-retry hiccup as a final failure. Genuinely
+        // terminal outcomes don't need this: a refusal flips AP_GetConnectionStatus() to
+        // ConnectionRefused, which ProcessConnectionAttempt() already resolves by clearing
+        // m_connectAttemptActive before this is queried again; a bridge-level timeout sets
+        // m_localConnectionError directly, which is returned above.
+        return "";
+    }
     const char* error = AP_GetLastConnectionError();
     if (error)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Ports the district Access Token softlock fix from [`cursor/fix-district-token-sync-b073`](https://github.com/247tossing/cyberpunk_archipelago/pull/25) (main lineage) onto `feature/v07`, which has diverged significantly (subdistrict gating, `districtTokenGatedMajorMask`/`IsDistrictTokenGated`, `ApplyDistrictRestrictionConfig`, vendor sanity, phone lock alerts, chat, richer DeathLink, NG+ prologue release). This is a **surgical port**, not a merge — none of v07's own systems were replaced or removed.

Also fixes a permanent `DISCONNECTED - Unable to connect to archipelago.gg on port <port>, error: Connect error: Success` regression reported after applying this port.

## Root cause (softlock, same as main)

`APGameState` and `APWeaponRestrictionEnforcer` extend Codeware's `ScriptableService`, whose lifecycle callback is **`OnLoad`**, not `OnAttach` (that's a `ScriptableSystem` callback). Both used `OnAttach`, so it never ran — `APGameState.items` stayed undefined for the whole session, and `SyncData()` had no data to work with after a save reload. Live grants still worked (quest facts set directly), but a player who reloaded and entered a restricted district before the AP server happened to resend that item live could get read as not owning it and get teleported out.

## What was ported (softlock fix)

1. **`APGameState`/`APWeaponRestrictionEnforcer`**: `OnAttach` → `OnLoad`; `GetItems()` lazily creates the list; added `itemResyncPending` + accessors. All v07 district/vendor/deathlink config APIs (`SetDistrictRestrictionConfig`, `IsDistrictTokenGated`, `SetVendorSanityData`, etc.) are untouched.
2. **`APGameSystem`**: `SyncData` null-safety guards; `HandleItemReceived`/`HandleItemSync`/`HandleProgressiveItem` route through `GetItems()`; `HandleItemSync`'s district-token branch now also retries `HandleDistrictUnlock` (v07 previously only tracked it, mirroring the existing weapon-pass behavior); spawn hook now arms the resync-pending deferral before `SyncData`. `ApplyDistrictRestrictionConfig`, NG+ prologue release, and journal quest tracking are unchanged.
3. **`TCPClient.Pump`**: added `itemResyncPending` arm/settle tracking (`ArmItemResyncPending`/`OnPlayerSpawned`); item-queue polling now gated on `APGameSystem` being available (same "don't drain the queue before a save loads" fix already on main) instead of always polling; dropped an extra `totalNetworkItemsReceived` gate that could skip district-unlock retries on resync. All v07-specific slot_data mirroring (district/weapon/vendor/deathlink config), chat polling, item notifications, and inbound DeathLink deferral are unchanged.
4. **`APDistrictManager`**: `HandleDistrictRestriction` now returns early while `itemResyncPending` is set, before any gated-district check or phone notification. `UnlockDistrict` only logs success when `SetQuestKey` actually succeeds. `IsDistrictTokenGated` early-out and the phone lock notification are unchanged.

## Connect error fix

Root cause: `"Connect error: Success"` is IXWebSocket's connect-failure reason string when the underlying errno/WSA code is `0` (strerror renders that as `"Success"`). APCpp stores this on every websocket `Error`/`Close` event, including the normal `wss://` → `ws://` retry/fallback sequence — not just genuine terminal failures. Two places treated the first such transient error as final:

- CET (`init.lua`): while `CONNECTING`, any non-empty `GetLastConnectionError()` immediately flipped the UI to `DISCONNECTED`.
- `TCPClient.Pump`: latched `initialized = false` the moment `AP_GetConnectionStatus()` read `Disconnected` (0) with a non-empty error, which the websocket does transiently between retries.

Combined with only a 10s attempt window before the native bridge gave up, the very first transient hiccup during a connect attempt was shown — and treated — as a permanent failure, so the connection never had a chance to recover.

Fix, layered:
1. **CET** (`init.lua`): `CONNECTING` now only ends on `IsConnected()`, an explicit refusal (`statusCode == 3`), or a timeout — raised from 10s to 30s. A transient error is shown as secondary status text instead of ending the attempt.
2. **`TCPClient.reds`**: the `initialized = false` latch now ignores errors matching the transient `"Success"` signature (defense in depth alongside the native suppression below). `Pump` also null-checks the `ScriptableSystemsContainer` once instead of calling `GetScriptableSystemsContainer().Get(...)` unconditionally on every tick.
3. **Native** (`APBridge.cpp`): `GetLastConnectionError()` now suppresses APCpp's raw (transient) error while a connect attempt is still active, only surfacing it once the attempt has genuinely ended (refusal or bridge-level timeout). The attempt timeout is raised from 10s to 30s to match CET.
4. **Native** (`Archipelago.cpp`): falls back from `wss://` to `ws://` on the first failed attempt instead of waiting for three retries, minimizing how long the misleading error can be visible.

## Testing

RedScript/native source changes only; no Linux-runnable compiler/bundle in this environment. Verified via brace/paren balance per file and full diff review against `origin/feature/v07` confirming no unrelated v07 behavior (vendor sanity, chat, DeathLink, NG+, journal, subdistrict gating) was touched. The native (`APBridge.cpp`/`Archipelago.cpp`) changes require rebuilding the `cyberpunk_ap_plugin`/APCpp DLL to take effect.

### In-game test plan
1. Connect to an AP slot on v07 with major-district restriction on and some districts gated.
2. Confirm log shows `Cyberpunk 2077 Archipelago Game State Ready` and spawn logs `Starting Item Sync - N tracked item(s)`.
3. Save, reload, and immediately enter a district whose token you already own — should not teleport.
4. Confirm auto-open (non-gated) districts still work normally, and a genuinely locked district still teleports once resync settles.
5. Confirm vendor sanity, DeathLink, and chat behavior are unaffected.
6. Connect to `archipelago.gg` and confirm the client reaches `CONNECTED` even if the first `wss://` attempt reports a transient error; confirm a genuine refusal/timeout still surfaces a clear message (not `Connect error: Success`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c808440-4355-4ff8-b560-731ebbd4b073?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c808440-4355-4ff8-b560-731ebbd4b073&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

