### PR TITLE
Add Phantom Liberty quest-chain prerequisites

### DIFF
--- a/worlds/cyberpunk2077/locations.py
+++ b/worlds/cyberpunk2077/locations.py
@@ -204,22 +204,44 @@ location_table: Dict[str, LocationData] = {
     # Phantom Liberty Checks
     # (Only applicable w/DLC)
     # =====================================
-    "q300_phantom_liberty": LocationData(display_name="Phantom Liberty - Phantom Liberty", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q301_crash": LocationData(display_name="Phantom Liberty - Dog Eat Dog", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY),
-    "q301_finding_myers": LocationData(display_name="Phantom Liberty - Hole in the Sky", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q301_q302_rescue_myers": LocationData(display_name="Phantom Liberty - Spider and the Fly", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q302_reed": LocationData(display_name="Phantom Liberty - Lucretia My Reflection", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY),
-    "q303_baron": LocationData(display_name="Phantom Liberty - The Damned", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q303_hands": LocationData(display_name="Phantom Liberty - Get It Together", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q303_songbird": LocationData(display_name="Phantom Liberty - You Know My Name", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q304_stadium": LocationData(display_name="Phantom Liberty - Birds with Broken Wings", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q304_netrunners": LocationData(display_name="Phantom Liberty - I've Seen That Face Before", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
-    "q304_deal": LocationData(display_name="Phantom Liberty - Firestarter", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY),
+    # Phantom Liberty (q300) is a Night City checklist quest; per the wiki
+    # (https://cyberpunk.fandom.com/wiki/Phantom_Liberty_(quest)) it only completes
+    # once ALL of the following main jobs are finished:
+    "q300_phantom_liberty": LocationData(
+        display_name="Phantom Liberty - Phantom Liberty",
+        regions=("Dogtown",),
+        category=LocationCategory.DLC_MAIN,
+        dlc_only=True,
+        prerequisite=(
+            "Prologue - The Heist",
+            "Main - Playing for Time",
+            "Main - Automatic Love",
+            "Main - The Space in Between",
+            "Main - Disasterpiece",
+            "Main - Double Life",
+            "Main - M'ap Tann Pèlen",
+            "Main - I Walk the Line",
+            "Main - Transmission",
+            "Main - Never Fade Away",
+        ),
+    ),
+    "q301_crash": LocationData(display_name="Phantom Liberty - Dog Eat Dog", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY, prerequisite="Phantom Liberty - Phantom Liberty"),
+    "q301_finding_myers": LocationData(display_name="Phantom Liberty - Hole in the Sky", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - Dog Eat Dog"),
+    "q301_q302_rescue_myers": LocationData(display_name="Phantom Liberty - Spider and the Fly", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - Hole in the Sky"),
+    "q302_reed": LocationData(display_name="Phantom Liberty - Lucretia My Reflection", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY, prerequisite="Phantom Liberty - Spider and the Fly"),
+    "q303_baron": LocationData(display_name="Phantom Liberty - The Damned", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - Lucretia My Reflection"),
+    "q303_hands": LocationData(display_name="Phantom Liberty - Get It Together", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - The Damned"),
+    "q303_songbird": LocationData(display_name="Phantom Liberty - You Know My Name", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - Get It Together"),
+    "q304_stadium": LocationData(display_name="Phantom Liberty - Birds with Broken Wings", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - You Know My Name"),
+    "q304_netrunners": LocationData(display_name="Phantom Liberty - I've Seen That Face Before", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, prerequisite="Phantom Liberty - Birds with Broken Wings"),
+    "q304_deal": LocationData(display_name="Phantom Liberty - Firestarter", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY, prerequisite="Phantom Liberty - I've Seen That Face Before"),
     # Firestarter splits the finale into Reed vs Songbird paths; only one branch is
     # playable per run. Three abstract checks cover both paths (see APQuestLocationLookup).
-    "pl_split_quest_1": LocationData(display_name="PL - Split Quest 1", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.EXCLUDED),
-    "pl_split_quest_2": LocationData(display_name="PL - Split Quest 2", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.EXCLUDED),
-    "pl_split_quest_3": LocationData(display_name="PL - Split Quest 3", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY),
+    "pl_split_quest_1": LocationData(display_name="PL - Split Quest 1", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.EXCLUDED, prerequisite="Phantom Liberty - Firestarter"),
+    "pl_split_quest_2": LocationData(display_name="PL - Split Quest 2", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.EXCLUDED, prerequisite="Phantom Liberty - Firestarter"),
+    "pl_split_quest_3": LocationData(display_name="PL - Split Quest 3", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True, progress_type=LocationProgressType.PRIORITY, prerequisite="Phantom Liberty - Firestarter"),
+    # "Who Wants to Live Forever" requires either finale path; the any_of(...) overlay
+    # is applied in rules.py since PrereqAny cannot be imported here without a cycle.
     "q307_before_tomorrow": LocationData(display_name="Phantom Liberty - Who Wants to Live Forever", regions=("Dogtown",), category=LocationCategory.DLC_MAIN, dlc_only=True),
 
     # =================================

--- a/worlds/cyberpunk2077/rules.py
+++ b/worlds/cyberpunk2077/rules.py
@@ -27,6 +27,15 @@ def any_of(*names: str) -> PrereqAny:
     return PrereqAny(tuple(names))
 
 
+# Firestarter splits the PL finale into Reed vs Songbird paths; only one branch is
+# playable per run, so "Who Wants to Live Forever" needs any one of the three splits.
+# Shared between the base (mixed DLC) and PL-only goal graphs.
+WHO_WANTS_TO_LIVE_FOREVER_PREREQUISITE: Prerequisite = any_of(
+    "PL - Split Quest 1",
+    "PL - Split Quest 2",
+    "PL - Split Quest 3",
+)
+
 # Overlay prerequisites used in normal (non-PL-only) goals.
 BASE_LOCATION_PREREQUISITES: dict[str, Prerequisite] = {
     "Point of No Return - Nocturne Op55N1": (
@@ -35,32 +44,20 @@ BASE_LOCATION_PREREQUISITES: dict[str, Prerequisite] = {
         "Main - Search and Destroy",
     ),
     "Ending Reached": "Point of No Return - Nocturne Op55N1",
+    "Phantom Liberty - Who Wants to Live Forever": WHO_WANTS_TO_LIVE_FOREVER_PREREQUISITE,
 }
 
 # Side chains now live on LocationData.prerequisite and apply in all goals.
 SIDE_QUEST_GOAL_PREREQUISITES: dict[str, Prerequisite] = {}
 
-# Phantom Liberty-only questline requirements.
+# Phantom Liberty-only questline requirements. This overlays (rather than replaces)
+# the LocationData-derived chain: the PL-only pool has no base-game checks, so
+# "Phantom Liberty - Phantom Liberty" is re-gated on Lifepath Chosen instead of the
+# full wiki AND-list used in the base goal (see LocationData.prerequisite in
+# locations.py for the in-game requirements of q300).
 PHANTOM_LIBERTY_ONLY_PREREQUISITES: dict[str, Prerequisite] = {
     "Phantom Liberty - Phantom Liberty": "Lifepath Chosen",
-    "Phantom Liberty - Dog Eat Dog": "Phantom Liberty - Phantom Liberty",
-    "Phantom Liberty - Hole in the Sky": "Phantom Liberty - Dog Eat Dog",
-    "Phantom Liberty - Spider and the Fly": "Phantom Liberty - Hole in the Sky",
-    "Phantom Liberty - Lucretia My Reflection": "Phantom Liberty - Spider and the Fly",
-    "Phantom Liberty - The Damned": "Phantom Liberty - Lucretia My Reflection",
-    "Phantom Liberty - Get It Together": "Phantom Liberty - The Damned",
-    "Phantom Liberty - You Know My Name": "Phantom Liberty - Get It Together",
-    "Phantom Liberty - Birds with Broken Wings": "Phantom Liberty - You Know My Name",
-    "Phantom Liberty - I've Seen That Face Before": "Phantom Liberty - Birds with Broken Wings",
-    "Phantom Liberty - Firestarter": "Phantom Liberty - I've Seen That Face Before",
-    "PL - Split Quest 1": "Phantom Liberty - Firestarter",
-    "PL - Split Quest 2": "Phantom Liberty - Firestarter",
-    "PL - Split Quest 3": "Phantom Liberty - Firestarter",
-    "Phantom Liberty - Who Wants to Live Forever": any_of(
-        "PL - Split Quest 1",
-        "PL - Split Quest 2",
-        "PL - Split Quest 3",
-    ),
+    "Phantom Liberty - Who Wants to Live Forever": WHO_WANTS_TO_LIVE_FOREVER_PREREQUISITE,
     "Ending Reached": "Phantom Liberty - Who Wants to Live Forever",
 }
 
@@ -79,7 +76,7 @@ def _collect_location_prerequisites() -> dict[str, Prerequisite]:
 LOCATION_PREREQUISITES: dict[str, dict[str, Prerequisite]] = {
     "base": {**_collect_location_prerequisites(), **BASE_LOCATION_PREREQUISITES},
     "all_side_quests": SIDE_QUEST_GOAL_PREREQUISITES,
-    "phantom_liberty_only": PHANTOM_LIBERTY_ONLY_PREREQUISITES,
+    "phantom_liberty_only": {**_collect_location_prerequisites(), **PHANTOM_LIBERTY_ONLY_PREREQUISITES},
 }
 
 # Internal ``location_table`` keys ``VendorCheck_*`` (sorted for stable slot_data order).

--- a/worlds/cyberpunk2077/test/test_location_graph.py
+++ b/worlds/cyberpunk2077/test/test_location_graph.py
@@ -65,6 +65,10 @@ class TestLocationGraph(unittest.TestCase):
         cycles = _find_cycles(self._edges_for_options({"completion_goal": 2}))
         self.assertFalse(cycles, f"Found cycles in PL-only prerequisites: {cycles}")
 
+    def test_mixed_dlc_goal_has_no_cycles(self) -> None:
+        cycles = _find_cycles(self._edges_for_options({"include_phantom_liberty_dlc": 1}))
+        self.assertFalse(cycles, f"Found cycles in mixed-DLC prerequisites: {cycles}")
+
     def test_prerequisite_targets_exist(self) -> None:
         multiworld = setup_multiworld([Cyberpunk2077World], options=[{}])
         world = multiworld.worlds[1]

--- a/worlds/cyberpunk2077/test/test_quest_chains.py
+++ b/worlds/cyberpunk2077/test/test_quest_chains.py
@@ -84,6 +84,88 @@ class TestPhantomLibertyQuestChains(Cyberpunk2077TestBase):
         )
 
 
+class TestPhantomLibertyMixedDlcChain(Cyberpunk2077TestBase):
+    """Phantom Liberty checks must be chained even outside the PL-only goal.
+
+    See https://cyberpunk.fandom.com/wiki/Phantom_Liberty_(quest) for the wiki
+    AND-list required to unlock the "Phantom Liberty" quest itself.
+    """
+
+    run_default_tests = False
+    options = {
+        "include_phantom_liberty_dlc": 1,
+    }
+
+    def test_phantom_liberty_requires_full_wiki_checklist(self) -> None:
+        edges = get_active_location_prerequisites(self.world)
+        self.assertEqual(
+            edges["Phantom Liberty - Phantom Liberty"],
+            (
+                "Prologue - The Heist",
+                "Main - Playing for Time",
+                "Main - Automatic Love",
+                "Main - The Space in Between",
+                "Main - Disasterpiece",
+                "Main - Double Life",
+                "Main - M'ap Tann Pèlen",
+                "Main - I Walk the Line",
+                "Main - Transmission",
+                "Main - Never Fade Away",
+            ),
+        )
+
+    def test_dogtown_chain_is_sequential(self) -> None:
+        edges = get_active_location_prerequisites(self.world)
+        self.assertEqual(edges["Phantom Liberty - Dog Eat Dog"], "Phantom Liberty - Phantom Liberty")
+        self.assertEqual(edges["Phantom Liberty - Hole in the Sky"], "Phantom Liberty - Dog Eat Dog")
+        self.assertEqual(edges["Phantom Liberty - Spider and the Fly"], "Phantom Liberty - Hole in the Sky")
+        self.assertEqual(edges["Phantom Liberty - Lucretia My Reflection"], "Phantom Liberty - Spider and the Fly")
+        self.assertEqual(edges["Phantom Liberty - The Damned"], "Phantom Liberty - Lucretia My Reflection")
+        self.assertEqual(edges["Phantom Liberty - Get It Together"], "Phantom Liberty - The Damned")
+        self.assertEqual(edges["Phantom Liberty - You Know My Name"], "Phantom Liberty - Get It Together")
+        self.assertEqual(edges["Phantom Liberty - Birds with Broken Wings"], "Phantom Liberty - You Know My Name")
+        self.assertEqual(
+            edges["Phantom Liberty - I've Seen That Face Before"],
+            "Phantom Liberty - Birds with Broken Wings",
+        )
+        self.assertEqual(
+            edges["Phantom Liberty - Firestarter"],
+            "Phantom Liberty - I've Seen That Face Before",
+        )
+
+    def test_who_wants_to_live_forever_needs_any_finale_split(self) -> None:
+        edges = get_active_location_prerequisites(self.world)
+        split_prereq = edges["Phantom Liberty - Who Wants to Live Forever"]
+        self.assertIsInstance(split_prereq, PrereqAny)
+        self.assertEqual(
+            split_prereq.names,
+            ("PL - Split Quest 1", "PL - Split Quest 2", "PL - Split Quest 3"),
+        )
+
+    def test_ending_reached_still_requires_nocturne_not_pl_capstone(self) -> None:
+        edges = get_active_location_prerequisites(self.world)
+        self.assertEqual(
+            edges["Ending Reached"],
+            "Point of No Return - Nocturne Op55N1",
+        )
+
+    def test_firestarter_not_reachable_before_required_districts_unlocked(self) -> None:
+        # Default options token-gate every major district touched by the wiki
+        # AND-list (Westbrook, Santo Domingo, Pacifica) as well as Dogtown itself.
+        self.assertFalse(self.can_reach_location("Phantom Liberty - Firestarter"))
+
+    def test_firestarter_reachable_after_unlocking_required_districts(self) -> None:
+        self.collect_by_name(
+            (
+                "Westbrook Access Token",
+                "Santo Domingo Access Token",
+                "Pacifica Access Token",
+                "Dogtown Access Token",
+            )
+        )
+        self.assertTrue(self.can_reach_location("Phantom Liberty - Firestarter"))
+
+
 class TestWestbrookTokenSoftlockRegression(Cyberpunk2077TestBase):
     run_default_tests = False
     options = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Dogtown/Phantom Liberty quests were unknown to the generator in mixed-DLC seeds (`include_phantom_liberty_dlc` on, any-ending goals). Every `DLC_MAIN` check was reachable as soon as Dogtown itself was (Lifepath Chosen + optional Dogtown Access Token), even though the sequential chain existed in `PHANTOM_LIBERTY_ONLY_PREREQUISITES` — that overlay only applied to the standalone "Complete Only Phantom Liberty Questline" goal, which replaced the whole prerequisite graph instead of merging into it. This let generation place progression items on late PL checks (e.g. Firestarter) before the in-game chain could actually be played, producing logic errors reported by users.

## Fix

Per the wiki ([Phantom Liberty (quest)](https://cyberpunk.fandom.com/wiki/Phantom_Liberty_(quest))), the `q300_phantom_liberty` checklist quest only completes once **all** of these main jobs are finished: The Heist, Playing for Time, Automatic Love, The Space in Between, Disasterpiece, Double Life, M'ap Tann Pèlen, I Walk the Line, Transmission, and Never Fade Away.

- [`worlds/cyberpunk2077/locations.py`](worlds/cyberpunk2077/locations.py): Added that wiki AND-list as `q300`'s `prerequisite`, plus sequential `LocationData.prerequisite` edges through the rest of the Dogtown main-quest chain (Dog Eat Dog → ... → Firestarter → the three finale-split checks).
- [`worlds/cyberpunk2077/rules.py`](worlds/cyberpunk2077/rules.py):
  - Extracted the shared `WHO_WANTS_TO_LIVE_FOREVER_PREREQUISITE` (`any_of` the three finale splits) used by both the base graph and the PL-only goal.
  - Added it to `BASE_LOCATION_PREREQUISITES` so mixed-DLC seeds gate the finale correctly.
  - Changed the PL-only goal to **merge** the LocationData-derived chain instead of replacing it, keeping only the necessary overlay: `q300` is re-gated on `Lifepath Chosen` (since that pool has no base-game checks), and `Ending Reached` still points at the PL capstone.
- Added mixed-DLC quest-chain tests (`TestPhantomLibertyMixedDlcChain`) verifying the wiki AND-list, the sequential Dogtown chain, the finale `any_of`, that `Ending Reached` still requires Nocturne (not the PL capstone), and that Firestarter is unreachable until the required token-gated districts are unlocked. Also added a cycle-detection test for the mixed-DLC prerequisite graph.

## Out of scope

- PL gigs, DLC_SIDE, tarot, and vendors (still gated only by district/token, unchanged)
- New named locations for the post-Firestarter Reed/Songbird quests (the existing split checks already cover both finales)
- RedScript ID mapping regeneration (no location keys or display names were added or renamed)

## Testing

Ran the `worlds/cyberpunk2077` test suite against a local Archipelago core checkout:
- All quest-chain, location-graph, token-locality, and defaults tests pass.
- Confirmed the `test_fill` failures seen in `test_completion_goals` / `test_deathlink` / `test_district_restrictions` / `test_vendor_sanity` are pre-existing on `main` (reproduced with this branch's changes stashed) and unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4328539a-3374-49b1-a1a7-fce3a935ca88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4328539a-3374-49b1-a1a7-fce3a935ca88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

