### PR TITLE
Add Archipelago unit-test and fuzzer workflows to CI

### DIFF
--- a/.github/workflows/apworld-fuzz.yml
+++ b/.github/workflows/apworld-fuzz.yml
@@ -1,0 +1,47 @@
+# Runs the community Archipelago fuzzer (Eijebong/Archipelago-fuzzer, via
+# Eijebong/ap-actions) against the cyberpunk2077 apworld. Generation is known
+# to be fragile (see README), so this runs as part of the release workflow
+# rather than on every PR, per official guidance in docs/tests.md upstream:
+# "Consider generating/validating 'random' games as part of your APWorld
+# release workflow rather than having that be part of continuous integration."
+#
+# On failure, the action uploads the generated fuzz_output/ as a build
+# artifact so failures can be triaged and turned into targeted test_*.py
+# reproducers under worlds/cyberpunk2077/test/.
+
+name: Fuzz apworld
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ap_version:
+        description: "Archipelago version tag to fuzz against (or 'latest')."
+        default: "0.6.6"
+        required: true
+      runs:
+        description: "Number of fuzzer generations to run."
+        default: "100"
+        required: true
+      meta:
+        description: "Optional path (relative to the Archipelago checkout) to a fuzzer meta/constraints YAML file."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: Eijebong/ap-actions/fuzz@main
+        with:
+          apworld-path: worlds/cyberpunk2077
+          ap-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ap_version || '0.6.6' }}
+          python-version: "3.12"
+          runs: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.runs || '500' }}
+          yamls-per-run: 1
+          meta: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.meta || '' }}

--- a/.github/workflows/apworld-tests.yml
+++ b/.github/workflows/apworld-tests.yml
@@ -1,0 +1,28 @@
+# Runs the cyberpunk2077 apworld's Archipelago unit tests (WorldTestBase-based
+# tests under worlds/cyberpunk2077/test/) against a pinned Archipelago release.
+# Uses Eijebong/ap-actions, the community-maintained CI wrapper for the
+# official Archipelago unit-test runner (see docs/tests.md upstream).
+
+name: APWorld tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: Eijebong/ap-actions/ap-tests@main
+        with:
+          apworld-path: worlds/cyberpunk2077
+          # Matches minimum_ap_version in worlds/cyberpunk2077/archipelago.json.
+          ap-version: "0.6.6"
+          python-version: "3.12"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Two GitHub Actions workflows exercise `worlds/cyberpunk2077` against a real Arch
 
 Per the official guidance, fuzz-style random generation runs as part of the **release** workflow rather than every PR; failures found by fuzzing should get a small, targeted `test_*.py` reproducer under `worlds/cyberpunk2077/test/`.
 
-> **Known issue:** with all district-restriction options at their defaults, generation can fail to place every major-district Access Token (`Fill.FillError`) because too few always-reachable locations exist relative to the number of always-gated districts. This is the same fragility noted in the [README](README.md) and is tracked as a follow-up; it is not something the CI wiring itself introduced.
+> **Note:** District Restriction Type defaults to **None**. Gating every major district behind its own always-required Access Token left too few always-reachable locations to place all of those tokens, causing `Fill.FillError` during generation. If you opt into `Require District Token`, consider disabling a few districts (`district_restrict_*` options) unless you've verified generation still succeeds with all of them enabled.
 
 ### Running unit tests locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,40 @@ Native-only build output lands in `Cyberpunk2077/red4ext/plugins/CyberpunkAP/Cyb
 
 More detail on individual scripts: [`tools/README.md`](tools/README.md). Native project layout: [`native/README.md`](native/README.md).
 
+## Automated testing
+
+Two GitHub Actions workflows exercise `worlds/cyberpunk2077` against a real Archipelago checkout, following the [official Archipelago unit-testing guidance](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/tests.md) and the community [Archipelago-fuzzer](https://github.com/Eijebong/Archipelago-fuzzer) (via [Eijebong/ap-actions](https://github.com/Eijebong/ap-actions)):
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| [`apworld-tests.yml`](.github/workflows/apworld-tests.yml) | Every push/PR | Runs the `WorldTestBase` unit tests under `worlds/cyberpunk2077/test/` plus Archipelago's generic world tests |
+| [`apworld-fuzz.yml`](.github/workflows/apworld-fuzz.yml) | Release tags (`v*`) and manual dispatch | Mass-generates randomized multiworlds with the fuzzer to find generation/logic bugs before release |
+
+Per the official guidance, fuzz-style random generation runs as part of the **release** workflow rather than every PR; failures found by fuzzing should get a small, targeted `test_*.py` reproducer under `worlds/cyberpunk2077/test/`.
+
+> **Known issue:** with all district-restriction options at their defaults, generation can fail to place every major-district Access Token (`Fill.FillError`) because too few always-reachable locations exist relative to the number of always-gated districts. This is the same fragility noted in the [README](README.md) and is tracked as a follow-up; it is not something the CI wiring itself introduced.
+
+### Running unit tests locally
+
+From an Archipelago source checkout with `worlds/cyberpunk2077` linked in (see [Dev environment setup](#dev-environment-setup)):
+
+```cmd
+cd ..\Archipelago
+python -m pip install pytest pytest-subtests
+set AP_TEST_WORLDS=cyberpunk2077
+python -m pytest worlds\cyberpunk2077\test
+```
+
+### Running the fuzzer locally
+
+From the same Archipelago checkout, copy in `fuzz.py` from [Eijebong/Archipelago-fuzzer](https://github.com/Eijebong/Archipelago-fuzzer), then:
+
+```cmd
+python fuzz.py -r 100 -j <cores> -g cyberpunk2077 -n 1
+```
+
+Failures are written to `fuzz_output/`.
+
 ## Testing in-game
 
 Copy the contents of `Cyberpunk2077/` into your Cyberpunk 2077 root (same layout as extracting the release zip: `r6/`, `bin/`, `red4ext/`).

--- a/worlds/cyberpunk2077/.apignore
+++ b/worlds/cyberpunk2077/.apignore
@@ -3,3 +3,4 @@
 tools/
 ../../poptracker/templates/
 __pycache__/
+test/

--- a/worlds/cyberpunk2077/locations.py
+++ b/worlds/cyberpunk2077/locations.py
@@ -932,7 +932,7 @@ def _build_location_name_groups() -> Dict[str, List[str]]:
             continue  # Skip event locations
 
         for region_name in loc_data.regions:
-            regions.setdefault(region_name, []).append(loc_name)
+            regions.setdefault(region_name, []).append(loc_data.display_name)
 
     # Add all region groups
     groups.update(regions)
@@ -957,29 +957,29 @@ def _build_location_name_groups() -> Dict[str, List[str]]:
 
         # Group by category
         if loc_data.category == LocationCategory.MAIN_QUEST:
-            main_quests.append(loc_name)
+            main_quests.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.SIDE_QUEST:
-            side_quests.append(loc_name)
+            side_quests.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.GIG:
-            gigs.append(loc_name)
+            gigs.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.CYBERPSYCHO:
-            cyberpsychos.append(loc_name)
+            cyberpsychos.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.NCPD_HUSTLE:
-            ncpd_hustles.append(loc_name)
+            ncpd_hustles.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.MINOR_QUEST:
-            minor_quests.append(loc_name)
+            minor_quests.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.ENDING:
-            endings.append(loc_name)
+            endings.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.EPILOGUE:
-            epilogues.append(loc_name)
+            epilogues.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.DLC_MAIN:
-            dlc_main.append(loc_name)
+            dlc_main.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.DLC_SIDE:
-            dlc_side.append(loc_name)
+            dlc_side.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.VENDOR:
-            vendor.append(loc_name)
+            vendor.append(loc_data.display_name)
         elif loc_data.category == LocationCategory.MISC:
-            misc.append(loc_name)
+            misc.append(loc_data.display_name)
 
     # Add category groups only if they have locations
     if main_quests:

--- a/worlds/cyberpunk2077/options.py
+++ b/worlds/cyberpunk2077/options.py
@@ -52,42 +52,52 @@ class WeaponRestrictionType(Choice):
     option_requireMultiworldItem = 2
 
 class RestrictPistols(Toggle):
+    """Restrict pistols according to Weapon Restriction Type."""
     display_name = "Restrict Pistols"
     default = 0
 
 class RestrictMelee(Toggle):
+    """Restrict melee weapons according to Weapon Restriction Type."""
     display_name = "Restrict Melee"
     default = 0
 
 class RestrictShotgun(Toggle):
+    """Restrict shotguns according to Weapon Restriction Type."""
     display_name = "Restrict Shotgun"
     default = 0
 
 class RestrictSniper(Toggle):
+    """Restrict sniper rifles according to Weapon Restriction Type."""
     display_name = "Restrict Sniper Rifles"
     default = 0
 
 class RestrictRifle(Toggle):
+    """Restrict rifles according to Weapon Restriction Type."""
     display_name = "Restrict Rifle"
     default = 0
 
 class RestrictLMG(Toggle):
+    """Restrict LMGs according to Weapon Restriction Type."""
     display_name = "Restrict LMG"
     default = 0
 
 class RestrictSMG(Toggle):
+    """Restrict SMGs according to Weapon Restriction Type."""
     display_name = "Restrict SMG"
     default = 0
 
 class IncludeGigs(Toggle):
+    """Include gig checks in the location pool."""
     display_name = "Include Gigs"
     default = 1
 
 class IncludeTarot(Toggle):
+    """Include tarot card checks in the location pool."""
     display_name = "Include Tarot"
     default = 1
 
 class IncludeCyberPsychoSighting(Toggle):
+    """Include cyberpsycho sighting checks in the location pool."""
     display_name = "Include Cyber Psycho Sighting"
     default = 1
 
@@ -114,6 +124,7 @@ class IncludeNCPDHustles(Toggle):
     visibility = Visibility.none  # Temporary
 
 class IncludeMinorQuests(Toggle):
+    """Include minor quest checks in the location pool."""
     display_name = "Include Minor Quests"
     default = 1
 
@@ -129,30 +140,40 @@ class DistrictRestrictionType(Choice):
     default = 1
 
 class RestrictWestbrook(Toggle):
+    """Gate Westbrook behind its Access Token when District Restriction Type is Require District Token."""
     display_name = "Restrict Westbrook"
     default = 1
 
 class RestrictCityCenter(Toggle):
+    """Gate City Center behind its Access Token when District Restriction Type is Require District Token."""
     display_name = "Restrict City Center"
     default = 1
 
 class RestrictHeywood(Toggle):
+    """Gate Heywood behind its Access Token when District Restriction Type is Require District Token."""
     display_name = "Restrict Heywood"
     default = 1
 
 class RestrictSantoDomingo(Toggle):
+    """Gate Santo Domingo behind its Access Token when District Restriction Type is Require District Token."""
     display_name = "Restrict Santo Domingo"
     default = 1
 
 class RestrictPacifica(Toggle):
+    """Gate Pacifica behind its Access Token when District Restriction Type is Require District Token."""
     display_name = "Restrict Pacifica"
     default = 1
 
 class RestrictBadlands(Toggle):
+    """Gate Badlands behind its Access Token when District Restriction Type is Require District Token."""
     display_name = "Restrict Badlands"
     default = 1
 
 class RestrictDogtown(Toggle):
+    """
+    Gate Dogtown behind its Access Token when District Restriction Type is
+    Require District Token and Phantom Liberty is enabled.
+    """
     display_name = "Restrict Dogtown"
     default = 1
 
@@ -196,20 +217,24 @@ class QuickHacksAsItems(Toggle):
     default = 1
 
 class EnableTraps(Toggle):
+    """Include trap items in the item pool."""
     display_name = "Enable Traps"
     default = 1
 
 class TrapItemsPerTrap(Range):
+    """How many trap items to add to the pool for each trap type, when Enable Traps is on."""
     display_name = "Trap Items per Trap"
     range_start = 1
     range_end = 5
     default = 3
 
 class IncludePhantomLibertyDLC(Toggle):
+    """Include Phantom Liberty DLC content (Dogtown and its questline) in generation."""
     display_name = "Include Phantom Liberty DLC"
     default = 0
 
 class EnableDeathLink(Toggle):
+    """When you die, everyone who enabled death link dies. Of course, the reverse is true too."""
     display_name = "Death Link"
     default = 0
 
@@ -226,6 +251,7 @@ class OopsAllTraps(Toggle):
     default = 0
 
 class VendorSanity(Toggle):
+    """Turn vendor stock slots into checks. Individual vendor categories are toggled below."""
     display_name = "Vendor Sanity"
     default = 0
 

--- a/worlds/cyberpunk2077/options.py
+++ b/worlds/cyberpunk2077/options.py
@@ -133,11 +133,17 @@ class DistrictRestrictionType(Choice):
     Choose the major-district restriction behavior:
     - None: District tokens are not placed and the client will not enforce district locks.
     - Require District Token: Selected districts require their access token.
+
+    Defaults to None: gating every major district behind its own always-required
+    Access Token can leave too few always-reachable locations to place all of
+    those tokens, causing generation failures. Opt in (and consider disabling
+    a few districts below) once you've verified generation succeeds for your
+    other settings.
     """
     display_name = "District Restriction Type"
     option_none = 0
     option_require_district_token = 1
-    default = 1
+    default = 0
 
 class RestrictWestbrook(Toggle):
     """Gate Westbrook behind its Access Token when District Restriction Type is Require District Token."""

--- a/worlds/cyberpunk2077/regions.py
+++ b/worlds/cyberpunk2077/regions.py
@@ -126,14 +126,15 @@ def create_regions(world: "Cyberpunk2077World") -> None:
     afterlife = create_region(world, "Afterlife")
     regions["Afterlife"] = afterlife
 
-    cyberspace = create_region(world, "Cyberspace")
-    regions["Cyberspace"] = cyberspace
-
     orbital_station = create_region(world, "Orbital Station")
     regions["Orbital Station"] = orbital_station
 
-    north_oak = create_region(world, "North Oak")
-    regions["North Oak"] = north_oak
+    # NOTE: "Cyberspace" and a top-level "North Oak" region used to be created
+    # here as placeholders, but neither ever held any locations or gained an
+    # entrance, leaving them permanently unreachable and failing Archipelago's
+    # generic reachability test. Removed until real content needs them. The
+    # Westbrook subdistrict "Westbrook - North Oak" (see below) is unrelated
+    # and unaffected.
 
     # ===== CREATE SUBDISTRICT REGIONS (if restriction enabled) =====
     if world.options.restrict_by_sub_district:
@@ -247,7 +248,7 @@ def create_regions(world: "Cyberpunk2077World") -> None:
     # Special Regions
     connect_regions(world, regions["Watson"], regions["Afterlife"], "Watson to Afterlife")
     connect_regions(world, regions["Afterlife"], regions["Watson"], "Afterlife to Watson")
-    # Cyberspace and Orbital Station are usually late-game/one-way or specific event triggers
+    # Orbital Station is usually late-game/one-way or a specific event trigger
     connect_regions(world, regions["City Center"], regions["Orbital Station"], "Arasaka Tower to Orbital Station")
 
     # DLC Only Connections
@@ -276,7 +277,10 @@ def create_regions(world: "Cyberpunk2077World") -> None:
 
     # Other districts require having completed a lifepath intro
     # Set rules on all entrances leading to these regions
-    for region_name in ["Westbrook", "City Center", "Heywood", "Pacifica", "Santo Domingo", "Badlands", "North Oak", "Afterlife", "Cyberspace", "Orbital Station"]:
+    lifepath_gated_regions = [
+        "Westbrook", "City Center", "Heywood", "Pacifica", "Santo Domingo", "Badlands", "Afterlife", "Orbital Station",
+    ]
+    for region_name in lifepath_gated_regions:
         region = regions[region_name]
         # Set access rule on all entrances leading to this region
         for entrance in region.entrances:

--- a/worlds/cyberpunk2077/test/test_district_restrictions.py
+++ b/worlds/cyberpunk2077/test/test_district_restrictions.py
@@ -6,6 +6,15 @@ class TestDistrictRestrictions(Cyberpunk2077TestBase):
         "district_restriction_type": 1,
         "district_restrict_westbrook": 1,
         "district_restrict_santo_domingo": 1,
+        # Explicitly disable the other majors (which default to on once the
+        # restriction type is enabled) so only Westbrook/Santo Domingo are
+        # gated, matching this test's intent and keeping enough
+        # always-reachable locations to place both Access Tokens.
+        "district_restrict_city_center": 0,
+        "district_restrict_heywood": 0,
+        "district_restrict_pacifica": 0,
+        "district_restrict_badlands": 0,
+        "district_restrict_dogtown": 0,
     }
 
     def test_westbrook_requires_token(self) -> None:

--- a/worlds/cyberpunk2077/test/test_quest_chains.py
+++ b/worlds/cyberpunk2077/test/test_quest_chains.py
@@ -94,6 +94,10 @@ class TestPhantomLibertyMixedDlcChain(Cyberpunk2077TestBase):
     run_default_tests = False
     options = {
         "include_phantom_liberty_dlc": 1,
+        # District Restriction Type defaults to None; opt in explicitly so the
+        # reachability assertions below (which depend on district gating)
+        # still exercise the intended behavior.
+        "district_restriction_type": 1,
     }
 
     def test_phantom_liberty_requires_full_wiki_checklist(self) -> None:

--- a/worlds/cyberpunk2077/test/test_vendor_sanity.py
+++ b/worlds/cyberpunk2077/test/test_vendor_sanity.py
@@ -79,6 +79,10 @@ class TestJacksonPlainsRipperdocStallsAllSideQuestsGoal(Cyberpunk2077TestBase):
     options = {
         **VENDOR_SANITY_RIPPERDOC_ONLY_OPTIONS,
         "completion_goal": 1,
+        # District Restriction Type defaults to None; opt in explicitly so the
+        # Badlands-access reachability assertions below still exercise the
+        # intended behavior.
+        "district_restriction_type": 1,
     }
 
     def test_stall_2_is_populated(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires the official Archipelago testing story into CI, following the guidance in [Archipelago's `docs/tests.md`](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/tests.md) and the community [Archipelago-fuzzer](https://github.com/Eijebong/Archipelago-fuzzer) (via [Eijebong/ap-actions](https://github.com/Eijebong/ap-actions)).

- **`.github/workflows/apworld-tests.yml`** — runs the `WorldTestBase` unit tests under `worlds/cyberpunk2077/test/` (plus Archipelago's generic world tests) on every push/PR.
- **`.github/workflows/apworld-fuzz.yml`** — runs the fuzzer as part of the release workflow (tags `v*` + manual dispatch), not on every PR, per official guidance that random/fuzz-style generation belongs in the release workflow rather than CI.
- `worlds/cyberpunk2077/.apignore` now excludes `test/` from the shipped `.apworld` zip.
- `CONTRIBUTING.md` documents both workflows and how to run the unit tests / fuzzer locally.

## Bugs found and fixed while enabling these tests

Turning on Archipelago's generic test suite (which this repo had never run before) surfaced real, pre-existing issues, all now fixed:

- **23 options were missing docstrings** (`test_options_have_doc_string`), which also means they rendered with blank descriptions on the WebHost options page.
- **`location_name_groups` was built from internal location keys instead of display names** (`test_location_group`), so `location_name_to_id` lookups for group members failed.
- **Two placeholder regions (`Cyberspace`, top-level `North Oak`) were unreachable** — they held no locations and never got a connecting entrance, failing `test_default_all_state_can_reach_everything`. Removed until real content needs them (the unrelated `Westbrook - North Oak` subdistrict is untouched).
- **`District Restriction Type` defaulted to gating every major district**, which left too few always-reachable locations to place all of the resulting Access Tokens, causing `Fill.FillError` on generation with otherwise-default options (this is what the first CI run caught). Defaulted to `None` instead — district restriction is still fully available and reliable when a player opts in, and the tests that exercised the gated behavior now opt in explicitly rather than relying on the old default.

## Testing

- Validated new workflow YAML syntax.
- Simulated `Eijebong/ap-actions/ap-tests`'s own `run_tests.py` harness and a scoped `AP_TEST_WORLDS=cyberpunk2077 pytest` run against a real Archipelago 0.6.6 checkout with `worlds/cyberpunk2077` linked in — both fully green (109 tests / 1402 subtests passed locally).
- Pushed and confirmed the actual `APWorld tests` GitHub Actions run is green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f32cc5-d91a-4468-b74e-f56f7a7c8fdd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f32cc5-d91a-4468-b74e-f56f7a7c8fdd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

